### PR TITLE
Add Voice & tone brand section

### DIFF
--- a/src/pages/-/astro/brand/index.astro
+++ b/src/pages/-/astro/brand/index.astro
@@ -33,8 +33,8 @@ const sections = [
   },
   {
     title: "Voice & tone",
-    summary: "How the digital garden sounds — curious, plain, personal.",
-    href: null,
+    summary: "How the digital garden sounds. Curious, plain, personal.",
+    href: "/-/astro/brand/voice/",
     accent: "bg-zmoki-flame-500",
   },
 ];

--- a/src/pages/-/astro/brand/voice.astro
+++ b/src/pages/-/astro/brand/voice.astro
@@ -1,0 +1,347 @@
+---
+import BrandLayout from "@/layouts/BrandLayout.astro";
+
+// The four voice pillars. Each is a single principle with a short gloss and a
+// one-line "in practice" cue, derived from the persona in AGENTS.md and the
+// way the existing feed posts already sound.
+const pillars = [
+  {
+    label: "Curious",
+    accent: "bg-zmoki-flame-500",
+    text: "text-zmoki-flame-600",
+    summary: "Write from genuine interest.",
+    detail:
+      "Follow the rabbit hole and show where it leads. Let one post wander across tech, art, and research. Curiosity is the only connecting thread, so let it set the agenda.",
+  },
+  {
+    label: "Plain-spoken",
+    accent: "bg-zmoki-azure-500",
+    text: "text-zmoki-azure-600",
+    summary: "Short words, concrete examples, no jargon walls.",
+    detail:
+      "Say it the way you would say it to a friend. Prefer the simple word over the impressive one. When a term is unavoidable, define it on the spot so nobody has to already know it.",
+  },
+  {
+    label: "Personal",
+    accent: "bg-zmoki-magenta-500",
+    text: "text-zmoki-magenta-600",
+    summary: "First person, honest, a two-way conversation.",
+    detail:
+      "This is a map of one brain. Use “I”. Admit when something feels unfinished or uncertain, because the garden is intentionally imperfect, and invite the reader to write back.",
+  },
+  {
+    label: "Neurodivergent-friendly",
+    accent: "bg-zmoki-jade-500",
+    text: "text-zmoki-jade-600",
+    summary: "Clear structure, scannable, no rigid pressure.",
+    detail:
+      "Lead with headings, lists, and short paragraphs so a post can be skimmed or read in any order. Be generous with definitions and links. Never shame the reader or yourself for energy, pace, or schedule.",
+  },
+];
+
+// Mechanical house rules. These are the easy-to-miss habits that keep the voice
+// consistent. Each one is modelled by the page itself.
+const mechanics = [
+  {
+    rule: "Write headings in sentence case",
+    right: "Why I’m building a digital garden",
+    wrong: "Why I’m Building A Digital Garden",
+  },
+  {
+    rule: "Say it straight",
+    right: "The garden grows as I learn.",
+    wrong: "It’s not a blog, it’s a living garden.",
+  },
+  {
+    rule: "Go easy on dashes and colons",
+    right: "The goal is simple. Show the process, imperfections and all.",
+    wrong: "The goal is simple: show the process, imperfections and all.",
+  },
+];
+
+// Side-by-side rewrites. The "wrong" is the generic content-marketing default;
+// the "right" is drawn from or modelled on real lines in the feed.
+const examples = [
+  {
+    context: "Opening a post",
+    wrong: "In today’s fast-paced digital landscape, leveraging synergies is paramount.",
+    right:
+      "For years I thought about starting a website. The advice never changed. Find your niche.",
+    note: "Open on a real moment.",
+  },
+  {
+    context: "Explaining a term",
+    wrong: "A digital garden utilises non-linear knowledge-management paradigms.",
+    right:
+      "A digital garden is simply a website that grows and evolves organically, like a real garden.",
+    note: "Define with a familiar image, then move on.",
+  },
+  {
+    context: "Setting expectations",
+    wrong: "New content published every Monday, Wednesday, and Friday without fail.",
+    right: "Honestly, I don’t have a schedule. I’ll post when I’ve fallen down a new rabbit hole.",
+    note: "Be honest about your pace.",
+  },
+  {
+    context: "Inviting feedback",
+    wrong: "Please submit all inquiries via the contact form below.",
+    right: "If a post resonates or you spot a mistake, I’d genuinely love to hear from you.",
+    note: "Make it a conversation and name the real address.",
+  },
+];
+
+// Good FAQ-style questions, modelled on the FAQ in the digital-garden post.
+const sampleQuestions = [
+  "What exactly is a digital garden?",
+  "How often will you post?",
+  "How did you build this site?",
+  "Why reject the niche?",
+];
+
+// Words that carry the voice vs. words that quietly break it.
+const lexicon = {
+  use: [
+    "digital garden",
+    "curiosity",
+    "rabbit hole",
+    "hyper-fixation",
+    "the process",
+    "living / growing",
+    "map of my brain",
+    "intentionally imperfect",
+    "neurodivergent",
+    "in public",
+  ],
+  avoid: [
+    "leverage",
+    "synergy",
+    "paradigm",
+    "hustle",
+    "guru / ninja",
+    "supercharge",
+    "unlock",
+    "10x",
+    "content machine",
+    "thought leadership",
+  ],
+};
+
+// How the voice shows up in interface copy, not just prose.
+const microcopy = [
+  {
+    pattern: "Actions are plain verbs",
+    example: "“View →”, “Copy”, “Read the post”",
+    note: "Name the action and skip the marketing verbs.",
+  },
+  {
+    pattern: "Links describe their destination",
+    example: "“my guide to Tbilisi’s clothes swaps”, never “click here”",
+    note: "The link text should make sense read aloud on its own.",
+  },
+  {
+    pattern: "Empty and unfinished states stay honest",
+    example: "“Coming soon”, “Intentionally imperfect”",
+    note: "Don’t dress up a gap as a feature.",
+  },
+  {
+    pattern: "Errors are kind and human",
+    example: "“This page wandered off” over “404 resource not found”",
+    note: "Talk to the person who hit the error.",
+  },
+];
+
+// A quick self-check that folds the whole guide into one pre-publish pass.
+const checklist = [
+  "It sounds like you talking to a curious friend.",
+  "Headings and the title are in sentence case.",
+  "Every term a newcomer might not know is defined on the spot.",
+  "Each point is said straight, with no “not this, but that” setup.",
+  "Dashes and colons are rare, and the sentences still read well.",
+  "Headings and FAQ entries lead with What, Why, or How.",
+  "Links say where they go.",
+  "The post stays honest about pace and anything still unfinished.",
+];
+---
+
+<BrandLayout
+  title="Brand — Voice & tone"
+  description="How zmoki.xyz sounds: curious, plain-spoken, personal, neurodivergent-friendly"
+>
+  <header
+    class="mb-8 rounded-xl bg-zmoki-flame-500 px-6 py-10 text-zmoki-surface shadow-md md:px-10"
+  >
+    <a
+      href="/-/astro/brand/"
+      class="font-mono text-xs uppercase tracking-normal opacity-80 hover:opacity-100"
+      >← zmoki.xyz brand</a
+    >
+    <h1 class="mt-2 text-4xl font-semibold md:text-5xl">Voice &amp; tone</h1>
+    <p class="mt-4 max-w-2xl text-xl md:text-2xl">
+      zmoki.xyz is a user manual for one brain. It sounds curious, plain-spoken, personal, and
+      neurodivergent-friendly.
+    </p>
+  </header>
+
+  <!-- Who's speaking -->
+  <section class="mb-10 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <h2 class="mb-3 text-2xl font-semibold md:text-3xl">Who&rsquo;s speaking</h2>
+    <p class="max-w-2xl text-lg opacity-80">
+      One person who is a software engineer, contemporary artist, and neurodivergent researcher,
+      thinking out loud. The garden holds tech, art, and identity at once, and the only connecting
+      thread is genuine curiosity. Write the way that person would talk to a friend who is just as
+      curious.
+    </p>
+  </section>
+
+  <!-- Voice pillars -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">Voice pillars</h2>
+  <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+    {
+      pillars.map((pillar) => (
+        <section class="flex flex-col gap-3 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+          <span class={`h-2 w-12 rounded-full ${pillar.accent}`} />
+          <h3 class={`text-2xl font-semibold md:text-3xl ${pillar.text}`}>{pillar.label}</h3>
+          <p class="font-medium opacity-90">{pillar.summary}</p>
+          <p class="opacity-70">{pillar.detail}</p>
+        </section>
+      ))
+    }
+  </div>
+
+  <!-- Writing mechanics -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">House style</h2>
+  <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-3">
+    {
+      mechanics.map((m) => (
+        <section class="flex flex-col gap-3 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+          <h3 class="text-lg font-semibold">{m.rule}</h3>
+          <p class="bg-zmoki-jade-200/40 rounded-lg px-3 py-2 text-sm">
+            <span class="text-zmoki-jade-600 mr-1 font-mono text-xs uppercase tracking-normal">
+              Yes
+            </span>
+            {m.right}
+          </p>
+          <p class="bg-zmoki-flame-200/40 rounded-lg px-3 py-2 text-sm line-through opacity-70">
+            {m.wrong}
+          </p>
+        </section>
+      ))
+    }
+  </div>
+
+  <!-- Do / don't -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">Rewrites</h2>
+  <div class="mb-10 space-y-4">
+    {
+      examples.map((ex) => (
+        <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+          <p class="mb-4 font-mono text-xs uppercase tracking-normal opacity-60">{ex.context}</p>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div class="bg-zmoki-flame-200/40 rounded-lg border-l-4 border-zmoki-flame-500 p-4">
+              <p class="text-zmoki-flame-600 mb-1 font-mono text-xs uppercase tracking-normal">
+                Don&rsquo;t
+              </p>
+              <p class="opacity-80">{ex.wrong}</p>
+            </div>
+            <div class="bg-zmoki-jade-200/40 rounded-lg border-l-4 border-zmoki-jade-500 p-4">
+              <p class="text-zmoki-jade-600 mb-1 font-mono text-xs uppercase tracking-normal">Do</p>
+              <p class="opacity-80">{ex.right}</p>
+            </div>
+          </div>
+          <p class="mt-3 text-sm opacity-60">{ex.note}</p>
+        </section>
+      ))
+    }
+  </div>
+
+  <!-- Asking good questions -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">
+    Asking good questions
+  </h2>
+  <section class="mb-10 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <p class="max-w-2xl opacity-80">
+      Questions make strong headings and FAQ entries. Open questions that start with What, Why, or
+      How invite a full answer and let each section stand on its own. Closed yes or no questions
+      stop at a fact, so save them for the rare moment a fact is all you need. The full thinking
+      lives in
+      <a href="/feed/16-power-of-questions/" class="font-medium text-zmoki-azure-600 underline"
+        >the strategic power of questions</a
+      >, and the pattern is in the FAQ of
+      <a
+        href="/feed/2-why-im-building-a-digital-garden/"
+        class="font-medium text-zmoki-azure-600 underline"
+        >why I&rsquo;m building a digital garden</a
+      >.
+    </p>
+    <ul class="mt-5 flex flex-wrap gap-2">
+      {
+        sampleQuestions.map((q) => (
+          <li class="rounded-full bg-zmoki-azure-200/50 px-3 py-1 font-mono text-sm">{q}</li>
+        ))
+      }
+    </ul>
+  </section>
+
+  <!-- Lexicon -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">Words</h2>
+  <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <h3 class="text-zmoki-jade-600 mb-4 text-xl font-semibold">Use</h3>
+      <ul class="flex flex-wrap gap-2">
+        {
+          lexicon.use.map((word) => (
+            <li class="bg-zmoki-jade-200/50 rounded-full px-3 py-1 font-mono text-sm">{word}</li>
+          ))
+        }
+      </ul>
+    </section>
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <h3 class="text-zmoki-flame-600 mb-4 text-xl font-semibold">Avoid</h3>
+      <ul class="flex flex-wrap gap-2">
+        {
+          lexicon.avoid.map((word) => (
+            <li class="bg-zmoki-flame-200/50 rounded-full px-3 py-1 font-mono text-sm line-through opacity-70">
+              {word}
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </div>
+
+  <!-- UI microcopy -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">UI copy</h2>
+  <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <p class="mb-5 max-w-2xl opacity-80">
+      The same voice runs through interface copy, from buttons and links to empty states and errors.
+    </p>
+    <div class="grid grid-cols-1 gap-x-8 gap-y-5 sm:grid-cols-2">
+      {
+        microcopy.map((item) => (
+          <div>
+            <h3 class="font-semibold">{item.pattern}</h3>
+            <p class="mt-1 font-mono text-sm text-zmoki-azure-600">{item.example}</p>
+            <p class="mt-1 text-sm opacity-60">{item.note}</p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <!-- Pre-publish checklist -->
+  <h2 class="mb-4 mt-10 px-1 font-mono text-sm uppercase tracking-normal opacity-60">
+    Before you publish
+  </h2>
+  <section class="rounded-xl bg-zmoki-azure-900 p-6 text-slate-50 shadow-md md:p-8">
+    <ul class="space-y-3">
+      {
+        checklist.map((item) => (
+          <li class="flex items-start gap-3">
+            <span class="mt-1 h-4 w-4 shrink-0 rounded border-2 border-zmoki-azure-300" />
+            <span class="opacity-90">{item}</span>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+</BrandLayout>


### PR DESCRIPTION
Builds the **Voice & tone** section of the brand design system at `/-/astro/brand/voice/` and links it from the brand home (previously a "Coming soon" card).

Closes #6.

## What's on the page
- **Who's speaking** — anchors the voice to one person (engineer / artist / neurodivergent researcher)
- **Voice pillars** — Curious, Plain-spoken, Personal, Neurodivergent-friendly, each color-coded to a token family
- **House style** — sentence case, say it straight (no contrast framing), go easy on dashes and colons
- **Rewrites** — side-by-side do/don't for post writing, drawn from real lines in the feed
- **Asking good questions** — open What/Why/How questions for headings and FAQs, folding in the `power-of-questions` post and the FAQ pattern from `why-im-building-a-digital-garden`
- **Words** — use/avoid lexicon
- **UI copy** — voice in buttons, links, empty states, and errors
- **Before you publish** — a pre-publish checklist that folds the whole guide into one self-check

The page models its own rules (sentence case, direct phrasing, minimal dashes/colons). All content is synthesized from existing feed posts and the AGENTS.md persona; no inline hex, everything uses `zmoki-*` tokens.

## Verification
- `npm run check` — 0 errors
- `npm run format` — clean
- `npm run build` — 25 pages built, voice page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)