### PR TITLE
feat: add Typography brand guideline page

### DIFF
--- a/src/pages/-/astro/brand/index.astro
+++ b/src/pages/-/astro/brand/index.astro
@@ -22,7 +22,7 @@ const sections = [
   {
     title: "Typography",
     summary: "Type scale, weights, and the Noto Sans / Noto Sans Mono pairing.",
-    href: null,
+    href: "/-/astro/brand/typography/",
     accent: "bg-zmoki-azure-500",
   },
   {

--- a/src/pages/-/astro/brand/typography.astro
+++ b/src/pages/-/astro/brand/typography.astro
@@ -1,0 +1,350 @@
+---
+import BrandLayout from "@/layouts/BrandLayout.astro";
+import { accents, neutrals } from "@/design-tokens.mjs";
+
+// Pull real tokens so the link-treatment swatches can never drift from
+// what Tailwind actually generates (mirrors the Color page approach).
+const accentScales = accents as Record<string, Record<string, string>>;
+const neutralTokens = neutrals as Record<string, string>;
+
+// ---------------------------------------------------------------------------
+// Part 1 — Design typography (UI type scale)
+// Each step renders live with the exact utility classes used in the real
+// layouts/components, so the specimen is the source of truth.
+// ---------------------------------------------------------------------------
+const typeScale = [
+  {
+    label: "Hero",
+    classes: "text-4xl font-semibold xl:text-6xl",
+    sample: "A digital garden",
+    usage: "Post titles (PostLayout h1)",
+  },
+  {
+    label: "Lede",
+    classes: "text-2xl xl:text-3xl",
+    sample: "Ideas, art, and research, kept in the open.",
+    usage: "Post descriptions (PostLayout)",
+  },
+  {
+    label: "Section heading",
+    classes: "text-3xl font-medium md:text-4xl",
+    sample: "Resources",
+    usage: "Sidebar panels & author bio (h2)",
+  },
+  {
+    label: "Card title",
+    classes: "text-2xl font-semibold leading-normal xl:text-3xl",
+    sample: "On keeping a garden",
+    usage: "PostCard (h3)",
+  },
+  {
+    label: "Body",
+    classes: "text-lg xl:text-xl",
+    sample: "The base reading size — Noto Sans, set tight.",
+    usage: "Global body (BaseLayout)",
+  },
+] as const;
+
+// Mono-set UI labels — small, uppercase, tracked normal.
+const monoLabels = [
+  {
+    label: "Eyebrow / meta",
+    classes: "font-mono text-xs uppercase tracking-normal",
+    sample: "20 Jun 2026",
+    usage: "Dates, eyebrows (PostCard, PostLayout)",
+  },
+  {
+    label: "Previous / Next",
+    classes: "font-mono text-sm uppercase tracking-normal",
+    sample: "Previous",
+    usage: "Post navigation (PostLayout)",
+  },
+  {
+    label: "Button text",
+    classes: "font-mono text-xs font-medium uppercase tracking-normal",
+    sample: "Copy",
+    usage: "Copy / action buttons",
+  },
+] as const;
+
+// Tracking & leading conventions — the analysis flagged drift between
+// tracking-tight / -tighter / -normal. This documents the intended rule.
+const trackingRules = [
+  {
+    token: "tracking-tight",
+    rule: "Default for sans headings & body",
+    where: "Global body (BaseLayout)",
+  },
+  {
+    token: "tracking-tighter",
+    rule: "Colored & dark panels, logo scrim",
+    where: "Author / Resources / Contact sidebars",
+  },
+  {
+    token: "tracking-normal",
+    rule: "All mono labels — eyebrows, meta, buttons",
+    where: "Dates, Previous/Next, copy button",
+  },
+];
+
+const leadingRules = [
+  { token: "leading-tight", rule: "Body copy & headings", where: "Global body (BaseLayout)" },
+  { token: "leading-normal", rule: "Multi-line titles", where: "PostCard, prev/next titles" },
+];
+
+// ---------------------------------------------------------------------------
+// Part 2 — Prose typography (MDX .prose content)
+// Link treatments sourced from real tokens.
+// ---------------------------------------------------------------------------
+const linkTreatments = [
+  {
+    label: "Base link",
+    attr: "a",
+    color: accentScales["zmoki-azure"]["500"],
+    border: "dotted 4px",
+    token: "zmoki-azure-500",
+  },
+  {
+    label: "External",
+    attr: "[data-external]",
+    color: accentScales["zmoki-flame"]["500"],
+    border: "dotted 4px",
+    token: "zmoki-flame-500",
+  },
+  {
+    label: "Resource",
+    attr: "[data-resource]",
+    color: accentScales["zmoki-jade"]["500"],
+    border: "dotted 4px",
+    token: "zmoki-jade-500",
+  },
+  {
+    label: "Anchor",
+    attr: "[data-anchor]",
+    color: neutralTokens["zmoki-ink"],
+    border: "dashed 2px",
+    token: "zmoki-ink",
+  },
+];
+---
+
+<BrandLayout title="Brand — Typography" description="zmoki.xyz typography scale and prose styles">
+  <header class="mb-8 rounded-xl bg-zmoki-azure-900 px-6 py-10 text-slate-50 shadow-md md:px-10">
+    <a
+      href="/-/astro/brand/"
+      class="font-mono text-xs uppercase tracking-normal opacity-80 hover:opacity-100"
+      >← zmoki.xyz brand</a
+    >
+    <h1 class="mt-2 text-4xl font-semibold md:text-5xl">Typography</h1>
+    <p class="mt-4 max-w-2xl text-xl md:text-2xl">
+      Two type systems: a sans/mono pairing for the interface, and a tuned
+      <code class="font-mono">.prose</code> layer for written content. Every specimen below renders with
+      its real utility classes.
+    </p>
+  </header>
+
+  <!-- ===================================================================== -->
+  <!-- Part 1 — Design typography                                            -->
+  <!-- ===================================================================== -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">
+    Part 1 · Design typography
+  </h2>
+
+  <!-- Font pairing -->
+  <div class="mb-6 grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <p class="font-mono text-xs uppercase tracking-normal opacity-60">Interface · font-sans</p>
+      <p class="mt-2 text-5xl font-semibold">Noto Sans</p>
+      <p class="mt-3 text-lg opacity-80">Headings, body, buttons. Weights in use: 400, 500, 600.</p>
+      <p class="mt-4 font-sans text-2xl">AaBbCc 0123 — æ ß ç</p>
+    </section>
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <p class="font-mono text-xs uppercase tracking-normal opacity-60">Meta · font-mono</p>
+      <p class="mt-2 font-mono text-5xl font-semibold">Noto Sans Mono</p>
+      <p class="mt-3 text-lg opacity-80">
+        Eyebrows, dates, Previous/Next, buttons — always uppercase, tracked normal.
+      </p>
+      <p class="mt-4 font-mono text-2xl">AaBbCc 0123 — æ ß ç</p>
+    </section>
+  </div>
+
+  <!-- Type scale -->
+  <section class="mb-6 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <h3 class="mb-5 text-2xl font-semibold md:text-3xl">Type scale</h3>
+    <div class="divide-y divide-slate-200">
+      {
+        typeScale.map((step) => (
+          <div class="grid items-baseline gap-2 py-5 md:grid-cols-[10rem_1fr]">
+            <div>
+              <p class="font-medium">{step.label}</p>
+              <p class="mt-1 font-mono text-xs opacity-60">{step.usage}</p>
+            </div>
+            <div>
+              <p class={step.classes}>{step.sample}</p>
+              <p class="mt-2 font-mono text-xs lowercase opacity-50">{step.classes}</p>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+
+    <h3 class="mb-5 mt-8 text-2xl font-semibold md:text-3xl">Mono labels</h3>
+    <div class="divide-y divide-slate-200">
+      {
+        monoLabels.map((step) => (
+          <div class="grid items-baseline gap-2 py-5 md:grid-cols-[10rem_1fr]">
+            <div>
+              <p class="font-medium">{step.label}</p>
+              <p class="mt-1 font-mono text-xs opacity-60">{step.usage}</p>
+            </div>
+            <div>
+              <p class={step.classes}>{step.sample}</p>
+              <p class="mt-2 font-mono text-xs lowercase opacity-50">{step.classes}</p>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <!-- Tracking & leading -->
+  <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <h3 class="mb-4 text-2xl font-semibold">Tracking</h3>
+      <ul class="space-y-4">
+        {
+          trackingRules.map((r) => (
+            <li>
+              <code class="font-mono text-sm font-medium text-zmoki-azure-600">{r.token}</code>
+              <p class="text-base opacity-80">{r.rule}</p>
+              <p class="font-mono text-xs opacity-50">{r.where}</p>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+    <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+      <h3 class="mb-4 text-2xl font-semibold">Leading</h3>
+      <ul class="space-y-4">
+        {
+          leadingRules.map((r) => (
+            <li>
+              <code class="font-mono text-sm font-medium text-zmoki-azure-600">{r.token}</code>
+              <p class="text-base opacity-80">{r.rule}</p>
+              <p class="font-mono text-xs opacity-50">{r.where}</p>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </div>
+
+  <!-- ===================================================================== -->
+  <!-- Part 2 — Prose typography                                             -->
+  <!-- ===================================================================== -->
+  <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">
+    Part 2 · Prose typography
+  </h2>
+
+  <!-- Prose config -->
+  <section class="mb-6 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <h3 class="mb-4 text-2xl font-semibold md:text-3xl">.prose configuration</h3>
+    <p class="mb-4 opacity-80">
+      MDX content renders inside <code class="font-mono">prose prose-xl</code> (stepping up to
+      <code class="font-mono">2xl:prose-2xl</code>). Overrides live in
+      <code class="font-mono">tailwind.config.mjs</code> via <code class="font-mono"
+        >typography()</code
+      >.
+    </p>
+    <ul class="space-y-2 font-mono text-sm">
+      <li>
+        <span class="text-zmoki-azure-600">--tw-prose-headings</span>
+        <span class="opacity-60">→ zmoki-ink</span>
+      </li>
+      <li>
+        <span class="text-zmoki-azure-600">--tw-prose-body</span>
+        <span class="opacity-60">→ zmoki-ink</span>
+      </li>
+      <li>
+        <span class="text-zmoki-azure-600">--tw-prose-bold</span>
+        <span class="opacity-60">→ zmoki-ink</span>
+      </li>
+      <li>
+        <span class="text-zmoki-azure-600">prose-headings:font-semibold</span>
+        <span class="opacity-60">→ heading weight (PostLayout)</span>
+      </li>
+    </ul>
+  </section>
+
+  <!-- Link treatments -->
+  <section class="mb-6 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
+    <h3 class="mb-5 text-2xl font-semibold md:text-3xl">In-prose links</h3>
+    <p class="mb-5 opacity-80">
+      Link color is driven by data attributes added by the <code class="font-mono"
+        >rehypeExternalLinks</code
+      > plugin. Each renders with its real token.
+    </p>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {
+        linkTreatments.map((link) => (
+          <div class="rounded-lg border border-slate-200 p-4">
+            <span
+              class="text-lg font-medium"
+              style={`color: ${link.color}; border-bottom: ${link.border} ${link.color};`}
+            >
+              {link.label}
+            </span>
+            <p class="mt-3 font-mono text-xs opacity-60">{link.attr}</p>
+            <p class="font-mono text-xs uppercase tracking-normal opacity-50">
+              {link.token} · {link.border}
+            </p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <!-- Live prose specimen -->
+  <section class="mb-10">
+    <h3 class="mb-4 px-1 text-2xl font-semibold md:text-3xl">Live specimen</h3>
+    <div
+      class="prose prose-xl max-w-none rounded-xl bg-zmoki-surface px-4 py-8 shadow-md prose-headings:font-semibold md:p-12"
+    >
+      <h1>The shape of a sentence</h1>
+      <p>
+        Prose body is set in Noto Sans at <code>prose-xl</code>, inheriting <strong
+          >ink-colored bold</strong
+        > and headings. This is a base <a href="/">internal link</a>, an
+        <a href="https://example.com" data-external="true">external link</a>, a
+        <a href="/resources/" data-resource="true">resource link</a>, and an
+        <a href="#lists" data-anchor="true">anchor link</a>.
+      </p>
+      <h2 id="lists">Lists</h2>
+      <ul>
+        <li>Unordered items use the prose default marker.</li>
+        <li>Inline <code>code</code> picks up the mono face.</li>
+      </ul>
+      <ol>
+        <li>Ordered items count up.</li>
+        <li>Then carry on.</li>
+      </ol>
+      <blockquote>
+        <p>A blockquote sets quoted material apart with a left rule and italic body.</p>
+      </blockquote>
+      <h2>Definition list</h2>
+      <dl>
+        <dt>Digital garden</dt>
+        <dd>A living, always-tended collection of notes and work in progress.</dd>
+        <dt>Now page</dt>
+        <dd>A snapshot of current focus, updated as things change.</dd>
+      </dl>
+      <h2>Code block</h2>
+      <p>
+        Fenced blocks are highlighted with Shiki (<code>catppuccin-latte</code>) and get a copy
+        button at build time. Hand-written here, they fall back to prose code styling:
+      </p>
+      <pre><code>const garden = ["posts", "resources", "now"];
+garden.forEach((bed) =&gt; tend(bed));</code></pre>
+    </div>
+  </section>
+</BrandLayout>


### PR DESCRIPTION
Builds the **Typography** section of the brand design system at `/-/astro/brand/typography/`. Closes #4.

One page, two parts, modeled on the Color page's "can't drift" approach — specimens render from real values.

## Part 1 — Design typography
- **Font pairing**: Noto Sans (`font-sans`) + Noto Sans Mono (`font-mono`) with glyph specimens.
- **Type scale** (Hero, Lede, Section heading, Card title, Body) and **mono labels** (eyebrow/meta, Previous/Next, button) rendered live with the exact utility classes pulled from the real layouts/components, each annotated with its source.
- **Tracking & leading** conventions, documenting the intended rule to resolve the flagged `tracking-tight` / `-tighter` / `-normal` drift.

## Part 2 — Prose typography
- `.prose` config overrides from `tailwind.config.mjs` (`--tw-prose-*` = `zmoki-ink`, size steps).
- The four in-prose link treatments sourced from real tokens (azure dotted, flame, jade, ink dashed).
- A live `.prose` specimen (headings, lists, blockquote, definition list, inline code, code block). Link hover/underline behavior now comes from the global base-layer rule added in #12, so no per-specimen class string is needed.

## Wrap-up
- Brand-home Typography card flipped from "Coming soon" to live.

## Notes
- Rebased on `main` to pick up #9 (Voice & tone) and #12 (Components + global link interaction).
- `npm run format`, `check`, `lint`, and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)