### PR TITLE
feat: add post 17 (site speed to GoodINP) + new-post skill

### DIFF
--- a/.claude/skills/new-post/SKILL.md
+++ b/.claude/skills/new-post/SKILL.md
@@ -1,0 +1,81 @@
+---
+description: Draft a new feed post (blog post) for zmoki.xyz with correct frontmatter, link conventions, and a voice-guide check before it is done.
+---
+
+# New post — zmoki.xyz
+
+Create a new post in the `feed` content collection and make sure it sounds like Zarema.
+
+Posts live at `src/content/feed/{order}-{slug}.mdx` (`.mdx` for most, `.md` for plain ones). The schema is in `src/content/config.ts`.
+
+## 1. Get the content
+
+Ask where the content comes from if it is not already clear: pasted/dictated text, a topic to draft from, or existing notes / a file / a URL. If drafting from scratch, write in the voice described in step 4 from the start, not after.
+
+## 2. Pick order and slug
+
+- **Order** — the next post is `(highest existing order) + 1`. Check with:
+  ```bash
+  ls src/content/feed/
+  ```
+  Order drives sort position and prev/next nav, so the newest post gets the highest number.
+- **Slug** — a short, lowercase, hyphenated noun phrase. No leading "the" (match existing slugs like `freedom-manifesto`, `power-of-questions`, `day-themes-system`). The URL becomes `/feed/{order}-{slug}/`.
+
+## 3. Write the frontmatter and body
+
+Frontmatter (all fields required by the `feed` schema):
+
+```yaml
+---
+title: "Sentence case title, quoted if it contains a comma or colon"
+description: "One or two sentences. This is the meta description and OG description."
+publishDate: "YYYY-MM-DD" # today
+contentModifiedDate: "YYYY-MM-DD" # today
+order: N
+---
+```
+
+Body rules:
+
+- **Do not repeat the title as an `# H1`** and do not repeat the description as the first paragraph. `PostLayout` renders both from frontmatter. Start the body with the first real section (`##`) or an intro paragraph.
+- **Internal links** use relative paths: `https://zmoki.xyz/feed/7-foo/` becomes `[text](/feed/7-foo/)`. The rehype pipeline styles internal, external, resource, and anchor links automatically from the path, so never hand-write target/rel attributes.
+- **External links** stay absolute (`https://goodinp.com/`).
+- **Images** go through the `src/images/tmp/` optimization pipeline, then `import PostImage from "@/components/PostImage.astro"` and use `<PostImage src={...} alt="...">caption</PostImage>`. See `16-power-of-questions.mdx` for the pattern. Skip images unless the user has them ready.
+
+## 4. Check it against the voice guide (do this before calling it done)
+
+The voice guide is `src/pages/-/astro/brand/voice.astro` (rendered at `/-/astro/brand/voice/`). Read it and apply the pre-publish checklist. The easy-to-miss mechanical rules:
+
+- **Say it straight.** No "not this, but that" framing. Rewrite `isn't X, it's Y`, `not a hunch, a spreadsheet`, `it's not a blog, it's a garden` into a plain statement.
+- **Go easy on colons and dashes.** Prefer two short sentences over `clause: clause`. Avoid em-dashes; a comma or full stop usually reads better.
+- **Sentence case** for the title and every heading.
+- **Define any term** a newcomer might not know, on the spot.
+- **Links describe their destination** (never "click here").
+- **Stay honest** about pace and anything unfinished. Do not claim something is built or shipped if it is not.
+
+Quick mechanical scan (run, then read and fix anything it flags):
+
+```bash
+FILE=src/content/feed/{order}-{slug}.mdx
+# colons in prose (ignores markdown links)
+awk 'NR>7' "$FILE" | grep -n ":" | grep -v "](/" || echo "no prose colons"
+# em-dashes
+grep -n "—" "$FILE" || echo "no em-dashes"
+# contrast framing
+grep -niE "isn't .*, it's|not .*, but|n't .*, (it|they)'" "$FILE" || echo "no contrast framing"
+```
+
+The grep is a hint, not the whole job — still read the post and judge it against the full guide.
+
+## 5. Format and verify
+
+```bash
+npx prettier --write "src/content/feed/{order}-{slug}.mdx"
+npm run check   # astro check — 0 errors expected
+```
+
+Then offer to start the dev server with `/run` and confirm the post renders at `/feed/{order}-{slug}/` (200) and shows on the homepage.
+
+## 6. Do not commit
+
+Leave committing and pushing to the user unless they explicitly ask.

--- a/src/content/feed/17-site-speed-work-that-became-goodinp.mdx
+++ b/src/content/feed/17-site-speed-work-that-became-goodinp.mdx
@@ -1,0 +1,61 @@
+---
+title: "The site speed work I avoided, and how it's becoming GoodINP"
+description: "When I started with my tech SEO client, site speed wasn't part of the deal. Then their INP kept breaking, and fixing it for good became my new project."
+publishDate: "2026-06-20"
+contentModifiedDate: "2026-06-20"
+order: 17
+---
+
+## The work I kept trying not to do
+
+In a past life I was a frontend lead, and one of the things I got genuinely good at was site speed. Squeezing down LCP, chasing layout shifts, making slow pages fast. I can do it well. I just don't enjoy it. Debugging why LCP or CLS is poor is some of the most boring work I know, and it gets worse when the site is legacy code I didn't write, where every fix is an archaeology dig through someone else's decisions.
+
+So when I started working with a client as a tech SEO consultant, we agreed up front that Core Web Vitals were outside our scope. I'd handle the SEO and relevance engineering.
+
+## The boundary I couldn't fully hold
+
+Their site, built on Webflow, was slow. The main culprit was a poor TTFB, the server taking too long to send the first byte. That one I couldn't leave alone, because it sits underneath everything else. But I still didn't want to do the grind myself, so I designed a caching system for their AWS infrastructure and handed their in-house engineers a diagram and a tech spec. They did a great job implementing it (and, I'll say it, the diagram was beautiful). TTFB went green.
+
+And then I forgot about site speed. I didn't even open the Core Web Vitals section of their Search Console. I had plenty of other tech SEO and relevance engineering work to do, and for a long stretch the speed nightmare was simply off my desk.
+
+## The day something broke
+
+Then the content marketing team asked me to look at their CWV report. INP specifically. It had been fine for months, and then on one particular day it just went bad.
+
+Regular readers know [the pattern by now](/feed/7-nerdy-curiosity-better-work/). I get an uneasy feeling, and I fall down a rabbit hole until the data tells me whether the feeling was right. This time I turned into a detective. What exactly happened on this day? I interviewed teammates. I went through the history of Webflow changes. I asked the analytics people who own the Google Tag Manager container whether they'd touched anything around that date. Nobody confessed.
+
+So I had no choice but to open DevTools and do some field analysis myself. And on every hurt page, the single biggest factor behind the bad INP was GTM.
+
+## Opening the container
+
+I requested access, found the changes made around the day INP dropped, and that settled it. The whole problem lived in Google Tag Manager.
+
+So I looked closer. And oh my. The container was huge. Dozens of tags and triggers, most of them firing on every page load, all stacked into one giant mess. Every campaign, every channel, every experiment had added one more tag, and nobody had ever taken one away.
+
+All those tags initializing at once become a single long task on the browser's main thread. The browser can only do one thing at a time there, so while it's busy spinning up tracking pixels, it can't respond to the person who just tapped a button. That delay is exactly what INP measures.
+
+## The fix, and the one rule
+
+Here's the constraint that makes this interesting. I know how much the analytics matter. You cannot just rip tags out. Conversion tracking, form listeners, the analytics config, break those and you've taken away the business's ability to measure itself, which is unforgivable.
+
+So I came up with my own framework for working with triggers and tags without hurting Core Web Vitals, INP in particular. What has to fire immediately stays. Everything else gets staggered, deferred, or merged. I wrote the whole thing up for the analytics team, and we fixed it together. INP went green.
+
+## And then it came back
+
+A few months later, bad INP again. Same cause, GTM. So I fixed it again, and added more instructions for everyone on how to work with the container properly.
+
+A few months after that, yes. Again.
+
+That's when it stopped feeling like a client task and started feeling like a pattern. The marketing team is doing exactly what they're supposed to, adding tags as the business grows. The container grows, the INP slides, someone notices weeks later, and a tech SEO like me gets handed the cleanup. Then it happens again. It's structural, and it's a loop.
+
+## Selling before building
+
+My first instinct was to build a tool that monitors GTM and fixes this on its own. But I've been here before, and building a product before you've validated demand is a good way to waste a year. So before writing any code, I went looking for evidence that the problem is bigger than one client.
+
+I went to my favorite place for this, the public Chrome UX Report, and pulled the origins with poor INP. Now I have a concrete list of exact domains that have the problem I know how to fix. Real domains, sitting in a spreadsheet, ready to call.
+
+So I'm starting with sales. I'm taking my early steps toward finding clients for the manual version of this work, where I fix your INP by hand, the same way I fixed my client's, without ever touching your analytics. If I'm any good at finding those clients and I collect enough cases, that's when I'll build the real product.
+
+In [the Freedom Manifesto](/feed/14-freedom-manifesto/) I wrote about wanting leveraged income, using twenty years of engineering to build systems instead of trading hours for dollars. **[GoodINP](https://goodinp.com/)** is the name I'm giving that ambition. Right now it's me, a list of domains, and a method that works. Later, if the demand is real, it becomes a tool.
+
+It started, like a lot of my best work, with a boring task I didn't want to do and a problem that refused to stay fixed. If your site stutters when people tap to buy and you suspect your tag manager, that's the exact thing I fix, by hand, today. And if you just want to watch a tech SEO try to turn a recurring headache into a product in public, stick around the garden.


### PR DESCRIPTION
## Summary

- New feed post **#17**, "The site speed work I avoided, and how it's becoming GoodINP" — a tech-SEO story about a recurring Google Tag Manager INP regression and turning the manual fix into a new project (validation stage, links to goodinp.com).
- New **`/new-post` skill** (`.claude/skills/new-post/SKILL.md`) that captures the post workflow: next order number, frontmatter + link conventions, the voice-guide pre-publish check, format/`astro check`, and "don't commit".

## Notes

- Order `17`, slug `site-speed-work-that-became-goodinp`, dates set to today.
- Internal links use relative `/feed/...` paths; GoodINP links out to the live site.
- Checked against the voice guide (`/-/astro/brand/voice/`): say it straight, easy on colons/dashes, sentence-case headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)