### PR TITLE
Redesign: bento-style site (home, garden, tech, posts, now, legal)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/mdx": "^4.3.12",
         "@astrojs/rss": "^4.0.14",
         "@astrojs/tailwind": "^6.0.2",
+        "@lucide/astro": "^1.22.0",
         "@tailwindcss/typography": "^0.5.19",
         "astro": "^5.16.4",
         "markdown-it": "^14.1.0",
@@ -36,6 +37,9 @@
         "prettier": "^3.7.4",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-tailwindcss": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1797,6 +1801,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@lucide/astro": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@lucide/astro/-/astro-1.22.0.tgz",
+      "integrity": "sha512-boiP+euOZaEPofCbcwzn650302IQiPn3aKZ1n6zLmlogcN/ctOoLPZxpybCIiW0ygOzw9Jju4WFO2bHwNsAQ3A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "astro": "^4 || ^5 || ^6 || ^7"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -7690,7 +7703,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13733,7 +13745,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/mdx": "^4.3.12",
     "@astrojs/rss": "^4.0.14",
     "@astrojs/tailwind": "^6.0.2",
+    "@lucide/astro": "^1.22.0",
     "@tailwindcss/typography": "^0.5.19",
     "astro": "^5.16.4",
     "markdown-it": "^14.1.0",

--- a/src/design-tokens.mjs
+++ b/src/design-tokens.mjs
@@ -7,6 +7,7 @@
 export const accents = {
   // zmoki-azure: primary links, navigation, hero sections, ink (900)
   "zmoki-azure": {
+    50: "#f2faff",
     200: "#b7e5ff",
     300: "#7ccfff",
     400: "#42b9ff",
@@ -28,6 +29,7 @@ export const accents = {
   // zmoki-jade: resource links, action buttons
   "zmoki-jade": {
     500: "#00f25a",
+    600: "#00cb4b",
   },
   // zmoki-flame: external links, Contact panel
   "zmoki-flame": {
@@ -41,8 +43,8 @@ export const accents = {
 
 // Neutrals — the structural palette. Flat single values, one per role.
 export const neutrals = {
-  "zmoki-bg": "#e2e8f0", // page background
-  "zmoki-surface": "#f8fafc", // cards & panels
+  "zmoki-bg": "#b7e5ff", // page background (mirrors zmoki-azure-200)
+  "zmoki-surface": "#f2faff", // cards & panels (mirrors zmoki-azure-50)
   "zmoki-ink": "#001d2e", // primary text (mirrors zmoki-azure-900)
   "zmoki-muted": "#475569", // muted / meta text
 };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,24 +1,18 @@
 ---
-import { getCollection, type CollectionEntry } from "astro:content";
-import ResourceLink from "@/components/ResourceLink.astro";
 import PostHog from "@/components/posthog.astro";
 
 export interface Props {
-  showRecentPosts?: boolean;
   title: string;
   description?: string;
   publishDate?: Date;
   contentModifiedDate?: Date;
-  accentColor?: "gray" | "blue" | "green" | "orange" | "pink";
 }
 
 const {
-  showRecentPosts = true,
   title,
   description = "A digital garden of ideas, art, and research",
   publishDate,
   contentModifiedDate,
-  accentColor = "gray",
 } = Astro.props;
 
 const isProduction = import.meta.env.PROD;
@@ -36,18 +30,6 @@ const pageImageWideUrl = new URL(
   `/og-images${isPageArticle ? pagePathname : "/"}wide.jpg`,
   currentBaseUrl,
 ).toString();
-
-// If showRecentPosts is true, get 3 latest posts from the feed collection
-let recentPosts: CollectionEntry<"feed">[] | null = null;
-
-if (showRecentPosts) {
-  const allPosts: CollectionEntry<"feed">[] = await getCollection("feed");
-  const sortedPosts = allPosts.sort((a, b) => b.data.order - a.data.order);
-  recentPosts = sortedPosts.slice(0, 3);
-}
-
-const allResources: CollectionEntry<"resources">[] = await getCollection("resources");
-const sortedResources = allResources.sort((a, b) => a.data.order - b.data.order);
 ---
 
 <!doctype html>
@@ -102,159 +84,6 @@ const sortedResources = allResources.sort((a, b) => a.data.order - b.data.order)
   <body
     class="min-h-full bg-zmoki-bg font-sans text-lg leading-tight tracking-tight text-zmoki-ink xl:text-xl"
   >
-    <div
-      class="grid w-full grid-cols-1 gap-4 p-2 lg:grid-cols-[29%_71%] lg:grid-rows-[200px_160px_minmax(160px,max-content)_200px_minmax(0,max-content)_1fr_minmax(0,max-content)] lg:gap-x-8 lg:py-8 lg:pl-4 lg:pr-12"
-    >
-      <!-- Header -->
-      <header
-        class="min-h-24 rounded-xl bg-zmoki-surface bg-[url(/zmoki.jpg)] bg-cover bg-center tracking-tighter shadow-md"
-      >
-        <div class="h-full w-full bg-white/10 px-2 py-4 lg:px-4">
-          <a href="/" class="inline-block bg-zmoki-azure-500 px-2 text-slate-50">zmoki.xyz</a>
-        </div>
-      </header>
-
-      <!-- Main Content -->
-      <main class="max-w-7xl rounded-xl max-lg:px-2 max-lg:pt-2 lg:row-span-7 lg:pb-4 lg:pr-4">
-        <slot />
-      </main>
-
-      <aside
-        class="flex flex-col gap-2 rounded-xl bg-zmoki-magenta-500 p-6 text-slate-50 shadow-md"
-      >
-        <h2 class="flex-1 pb-4 text-3xl font-medium md:text-4xl">Author</h2>
-        <p class="flex flex-col items-start gap-2 md:flex-row md:justify-between">
-          <a href="/feed/1-about-me/" class="inline-block border-b-4 border-dotted border-current"
-            >Zarema Khalilova</a
-          >
-          <a href="/now/" class="border-b-4 border-dotted border-current">now</a>
-        </p>
-      </aside>
-
-      <aside
-        class="flex flex-col gap-2 rounded-xl bg-slate-700 p-6 tracking-tighter text-slate-50 shadow-md"
-      >
-        <h2 class="flex-1 pb-4 text-3xl font-medium md:text-4xl">Resources</h2>
-        <ul>
-          {
-            sortedResources.map(({ slug }) => (
-              <li class="py-2">
-                <ResourceLink
-                  slug={slug}
-                  class="border-b-4 border-dotted border-current text-zmoki-jade-500"
-                />
-              </li>
-            ))
-          }
-        </ul>
-      </aside>
-
-      <aside
-        class="flex flex-col gap-2 rounded-xl bg-zmoki-flame-500 p-6 tracking-tighter text-slate-50 shadow-md"
-      >
-        <h2 class="flex-1 pb-4 text-3xl font-medium md:text-4xl">Contact</h2>
-        <p>
-          <a href="mailto:hey@zmoki.xyz" class="border-b-4 border-dotted border-current"
-            >hey@zmoki.xyz</a
-          >
-        </p>
-        <p>say hey!</p>
-      </aside>
-
-      {
-        recentPosts ? (
-          <aside class="flex flex-col gap-2 rounded-xl bg-slate-700 p-6 tracking-tighter text-slate-50 shadow-md">
-            <h2 class="flex-1 text-3xl font-medium md:text-4xl">Recent posts</h2>
-            <ul>
-              {recentPosts.map((post) => (
-                <li class="py-4">
-                  <a
-                    href={`/feed/${post.slug}/`}
-                    class="border-b-4 border-dotted border-current text-zmoki-azure-300"
-                    set:html={post.data.title}
-                  />
-                </li>
-              ))}
-            </ul>
-          </aside>
-        ) : (
-          <div />
-        )
-      }
-
-      {
-        isPageArticle ? (
-          <div
-            class:list={[
-              "flex w-[calc(50%+8px)] items-end border-r-8 border-dashed max-lg:hidden",
-              accentColor === "gray" && "border-slate-400",
-              accentColor === "blue" && "border-zmoki-azure-500",
-              accentColor === "green" && "border-zmoki-jade-500",
-              accentColor === "orange" && "border-zmoki-flame-500",
-              accentColor === "pink" && "border-zmoki-magenta-500",
-            ]}
-          >
-            <button
-              id="go-to-top-button"
-              class="group ml-4 flex flex-col items-center gap-2 text-zmoki-muted"
-            >
-              <span
-                class:list={[
-                  "font-mono text-5xl uppercase transition-all duration-200",
-                  accentColor === "gray" && "group-hover:text-slate-400",
-                  accentColor === "blue" && "group-hover:text-zmoki-azure-500",
-                  accentColor === "green" && "group-hover:text-zmoki-jade-500",
-                  accentColor === "orange" && "group-hover:text-zmoki-flame-500",
-                  accentColor === "pink" && "group-hover:text-zmoki-magenta-500",
-                ]}
-              >
-                &#8593;
-              </span>
-              <span class="font-mono text-xs uppercase group-hover:text-zmoki-ink">Go to top</span>
-            </button>
-          </div>
-        ) : (
-          <div />
-        )
-      }
-
-      <script is:inline>
-        document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-          window.posthog?.capture("contact_email_clicked", {
-            email: this.getAttribute("href").replace("mailto:", ""),
-          });
-        });
-      </script>
-
-      <script>
-        const goToTopButton = document.getElementById("go-to-top-button");
-        if (goToTopButton) {
-          goToTopButton.addEventListener("click", () => {
-            window.scrollTo({
-              top: 0,
-              behavior: "smooth",
-            });
-          });
-        }
-      </script>
-
-      <!-- Footer -->
-      <footer
-        class="row-span-2 self-end rounded-xl bg-zmoki-surface px-4 pb-4 pt-2 font-mono text-[0.625rem] uppercase tracking-normal text-zmoki-muted shadow-md xl:text-xs"
-      >
-        <div class="my-2">
-          <span>•</span>
-          <a href="/legal/privacy/">Privacy Policy</a>
-          <span>•</span>
-          <a href="/legal/terms/">Terms of Service</a>
-          <br />
-          <span>•</span>
-          <a href="https://github.com/Zmoki/zmoki.xyz" target="_blank" rel="noopener noreferrer"
-            >Source Code</a
-          >
-        </div>
-        <p>&copy; <a href="/">zmoki.xyz</a> 2025</p>
-      </footer>
-    </div>
+    <slot />
   </body>
 </html>

--- a/src/layouts/LegalLayout.astro
+++ b/src/layouts/LegalLayout.astro
@@ -122,9 +122,11 @@ const { title, description, publishDate, contentModifiedDate } = Astro.props;
   </section>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
       });
     });
   </script>

--- a/src/layouts/LegalLayout.astro
+++ b/src/layouts/LegalLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import Time from "@/components/Time.astro";
+import { GitBranch, Home, Mail, Palette, Scale, Sprout } from "@lucide/astro";
 
 const { title, description, publishDate, contentModifiedDate } = Astro.props;
 ---
@@ -11,9 +12,49 @@ const { title, description, publishDate, contentModifiedDate } = Astro.props;
   publishDate={publishDate}
   contentModifiedDate={contentModifiedDate}
 >
-  <section class="space-y-4">
+  <section class="mx-auto max-w-4xl space-y-4 p-2 lg:p-4">
+    <!-- Top nav bento -->
+    <nav class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Home class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Home</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >zmoki.xyz</span
+        >
+      </a>
+
+      <a
+        href="/garden/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Garden</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >garden</span
+        >
+      </a>
+
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <Mail class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Say hi</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >hey@zmoki.xyz</span
+        >
+      </a>
+    </nav>
+
+    <!-- Legal Header -->
     <header
-      class="flex flex-col gap-6 rounded-xl bg-zmoki-surface px-4 py-8 shadow-sm outline-dashed outline-8 -outline-offset-2 outline-slate-400 md:items-center md:p-16 md:text-center xl:p-20"
+      class="flex flex-col gap-6 rounded-xl bg-zmoki-surface px-4 py-8 shadow-md outline-dashed outline-8 -outline-offset-2 outline-slate-400 md:items-center md:p-16 md:text-center xl:p-20"
     >
       <h1 class="text-5xl font-semibold xl:text-6xl" set:html={title} />
       {description && <p class="text-2xl xl:text-3xl" set:html={description} />}
@@ -23,10 +64,68 @@ const { title, description, publishDate, contentModifiedDate } = Astro.props;
         <span>Updated on <Time datetime={contentModifiedDate} /></span>
       </p>
     </header>
+
+    <!-- Legal Content -->
     <section
-      class="prose max-w-none rounded-xl bg-zmoki-surface px-4 py-8 shadow-sm prose-headings:font-semibold md:p-16 xl:px-28 xl:py-16 [&_a]:text-zmoki-azure-500"
+      class="prose max-w-none rounded-xl bg-zmoki-surface px-4 py-8 shadow-md prose-headings:font-semibold md:p-16 xl:px-28 xl:py-16 [&_a]:text-zmoki-azure-500"
     >
       <slot />
     </section>
+
+    <!-- Footer bento -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="https://github.com/Zmoki/zmoki.xyz"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Source code</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >github.com</span
+        >
+      </a>
+
+      <a
+        href="/-/astro/brand/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Palette class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Design system</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >brand</span
+        >
+      </a>
+
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <Scale class="h-6 w-6 text-zmoki-muted" />
+        <h2 class="text-xl font-semibold">Legal</h2>
+        <p class="flex flex-wrap gap-4">
+          <a
+            href="/legal/privacy/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >policy</a
+          >
+          <a
+            href="/legal/terms/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >terms</a
+          >
+        </p>
+      </article>
+    </div>
   </section>
+
+  <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+  </script>
 </BaseLayout>

--- a/src/layouts/NowLayout.astro
+++ b/src/layouts/NowLayout.astro
@@ -130,9 +130,11 @@ const contentModifiedDate = new Date(rawcCntentModifiedDate);
   </section>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
       });
     });
   </script>

--- a/src/layouts/NowLayout.astro
+++ b/src/layouts/NowLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import Time from "@/components/Time.astro";
+import { GitBranch, Home, Mail, Palette, Scale, Sprout } from "@lucide/astro";
 
 const {
   title,
@@ -19,9 +20,49 @@ const contentModifiedDate = new Date(rawcCntentModifiedDate);
   publishDate={publishDate}
   contentModifiedDate={contentModifiedDate}
 >
-  <section class="space-y-4">
+  <section class="mx-auto max-w-4xl space-y-4 p-2 lg:p-4">
+    <!-- Top nav bento -->
+    <nav class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Home class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Home</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >zmoki.xyz</span
+        >
+      </a>
+
+      <a
+        href="/garden/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Garden</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >garden</span
+        >
+      </a>
+
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <Mail class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Say hi</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >hey@zmoki.xyz</span
+        >
+      </a>
+    </nav>
+
+    <!-- Now Header -->
     <header
-      class="flex flex-col gap-6 rounded-xl bg-zmoki-surface px-4 py-8 shadow-sm outline-dashed outline-8 -outline-offset-2 outline-zmoki-magenta-500 md:items-center md:p-16 md:text-center xl:p-20"
+      class="flex flex-col gap-6 rounded-xl bg-zmoki-surface px-4 py-8 shadow-md outline-dashed outline-8 -outline-offset-2 outline-zmoki-magenta-500 md:items-center md:p-16 md:text-center xl:p-20"
     >
       <h1 class="text-5xl font-semibold xl:text-6xl" set:html={title} />
       {description && <p class="text-2xl xl:text-3xl" set:html={description} />}
@@ -31,10 +72,68 @@ const contentModifiedDate = new Date(rawcCntentModifiedDate);
         <span>Updated on <Time datetime={contentModifiedDate} /></span>
       </p>
     </header>
+
+    <!-- Now Content -->
     <section
-      class="prose prose-xl max-w-none rounded-xl bg-zmoki-surface px-4 py-8 shadow-sm xl:prose-2xl prose-headings:font-semibold md:p-16 xl:px-28 xl:py-16 [&_a]:text-zmoki-azure-500"
+      class="prose prose-xl max-w-none rounded-xl bg-zmoki-surface px-4 py-8 shadow-md xl:prose-2xl prose-headings:font-semibold md:p-16 xl:px-28 xl:py-16"
     >
       <slot />
     </section>
+
+    <!-- Footer bento -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="https://github.com/Zmoki/zmoki.xyz"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Source code</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >github.com</span
+        >
+      </a>
+
+      <a
+        href="/-/astro/brand/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Palette class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Design system</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >brand</span
+        >
+      </a>
+
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <Scale class="h-6 w-6 text-zmoki-muted" />
+        <h2 class="text-xl font-semibold">Legal</h2>
+        <p class="flex flex-wrap gap-4">
+          <a
+            href="/legal/privacy/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >policy</a
+          >
+          <a
+            href="/legal/terms/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >terms</a
+          >
+        </p>
+      </article>
+    </div>
   </section>
+
+  <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+  </script>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -21,7 +21,6 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
   description={description}
   publishDate={publishDate}
   contentModifiedDate={contentModifiedDate}
-  accentColor="blue"
 >
   <article class="space-y-4">
     <!-- Post Header -->

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import type { CollectionEntry } from "astro:content";
 import Time from "@/components/Time.astro";
+import { GitBranch, Home, Mail, Palette, Scale, Sprout } from "@lucide/astro";
 
 export interface Props {
   title: string;
@@ -22,7 +23,46 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
   publishDate={publishDate}
   contentModifiedDate={contentModifiedDate}
 >
-  <article class="space-y-4">
+  <article class="mx-auto max-w-4xl space-y-4 p-2 lg:p-4">
+    <!-- Top nav bento -->
+    <nav class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Home class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Home</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >zmoki.xyz</span
+        >
+      </a>
+
+      <a
+        href="/garden/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Garden</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >garden</span
+        >
+      </a>
+
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <Mail class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Say hi</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >hey@zmoki.xyz</span
+        >
+      </a>
+    </nav>
+
     <!-- Post Header -->
     <header
       class="flex flex-col gap-6 rounded-xl bg-zmoki-surface px-4 py-8 outline-dashed outline-8 -outline-offset-2 outline-zmoki-azure-500 md:items-center md:p-16 md:text-center lg:p-20"
@@ -60,14 +100,13 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
 
     <!-- About Author -->
     <aside
-      class="space-y-2 rounded-xl bg-zmoki-surface px-4 py-8 leading-normal text-zmoki-ink shadow-md md:bg-zmoki-magenta-500 md:p-16 md:text-slate-50 xl:p-20"
+      class="space-y-2 rounded-xl bg-zmoki-surface px-4 py-8 leading-normal text-zmoki-ink shadow-md md:p-16 xl:p-20"
     >
       <h2 class="pb-4 text-3xl font-medium xl:text-4xl">Written by Zarema Khalilova</h2>
       <p>
         I'm a software engineer, a contemporary artist, and a neurodivergent researcher. This post
-        is one piece of my <a
-          href="/feed/2-why-im-building-a-digital-garden/"
-          class="border-b-4 border-dotted border-current">digital&nbsp;garden</a
+        is one piece of my <a href="/garden/" class="border-b-4 border-dotted border-current"
+          >digital&nbsp;garden</a
         >, where I explore the connections between all my different worlds. You can find the bigger
         picture on the <a href="/feed/1-about-me/" class="border-b-4 border-dotted border-current"
           >map&nbsp;of&nbsp;me</a
@@ -117,9 +156,63 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
         )
       }
     </nav>
+
+    <!-- Footer bento -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <a
+        href="https://github.com/Zmoki/zmoki.xyz"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold">Source code</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >github.com</span
+        >
+      </a>
+
+      <a
+        href="/-/astro/brand/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Palette class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold">Design system</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >brand</span
+        >
+      </a>
+
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <Scale class="h-6 w-6 text-zmoki-muted" />
+        <h2 class="text-xl font-semibold">Legal</h2>
+        <p class="flex flex-wrap gap-4">
+          <a
+            href="/legal/privacy/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >policy</a
+          >
+          <a
+            href="/legal/terms/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >terms</a
+          >
+        </p>
+      </article>
+    </div>
   </article>
 
   <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+
     document.querySelectorAll("a[data-nav-direction]").forEach(function (el) {
       el.addEventListener("click", function () {
         window.posthog?.capture("post_navigation_clicked", {

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -207,9 +207,11 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
   </article>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
       });
     });
 

--- a/src/layouts/ResourceLayout.astro
+++ b/src/layouts/ResourceLayout.astro
@@ -26,7 +26,6 @@ const isContentModified = contentModifiedDate.getTime() > publishDate.getTime();
   description={description}
   publishDate={publishDate}
   contentModifiedDate={contentModifiedDate}
-  accentColor="green"
 >
   <article class="space-y-4">
     <!-- Post Header -->

--- a/src/pages/-/astro/brand/voice.astro
+++ b/src/pages/-/astro/brand/voice.astro
@@ -216,7 +216,7 @@ const checklist = [
         <section class="flex flex-col gap-3 rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
           <h3 class="text-lg font-semibold">{m.rule}</h3>
           <p class="bg-zmoki-jade-200/40 rounded-lg px-3 py-2 text-sm">
-            <span class="text-zmoki-jade-600 mr-1 font-mono text-xs uppercase tracking-normal">
+            <span class="mr-1 font-mono text-xs uppercase tracking-normal text-zmoki-jade-600">
               Yes
             </span>
             {m.right}
@@ -244,7 +244,7 @@ const checklist = [
               <p class="opacity-80">{ex.wrong}</p>
             </div>
             <div class="bg-zmoki-jade-200/40 rounded-lg border-l-4 border-zmoki-jade-500 p-4">
-              <p class="text-zmoki-jade-600 mb-1 font-mono text-xs uppercase tracking-normal">Do</p>
+              <p class="mb-1 font-mono text-xs uppercase tracking-normal text-zmoki-jade-600">Do</p>
               <p class="opacity-80">{ex.right}</p>
             </div>
           </div>
@@ -286,7 +286,7 @@ const checklist = [
   <h2 class="mb-4 px-1 font-mono text-sm uppercase tracking-normal opacity-60">Words</h2>
   <div class="mb-10 grid grid-cols-1 gap-6 sm:grid-cols-2">
     <section class="rounded-xl bg-zmoki-surface p-6 shadow-md md:p-8">
-      <h3 class="text-zmoki-jade-600 mb-4 text-xl font-semibold">Use</h3>
+      <h3 class="mb-4 text-xl font-semibold text-zmoki-jade-600">Use</h3>
       <ul class="flex flex-wrap gap-2">
         {
           lexicon.use.map((word) => (

--- a/src/pages/garden.astro
+++ b/src/pages/garden.astro
@@ -2,7 +2,20 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection, type CollectionEntry } from "astro:content";
 import { firstPostImage } from "@/utils/post-image";
-import { Activity, Home, Mail, Sprout } from "@lucide/astro";
+import {
+  Activity,
+  BookOpen,
+  CalendarDays,
+  GitBranch,
+  Home,
+  Link,
+  ListChecks,
+  Mail,
+  MapPin,
+  Palette,
+  Scale,
+  Sprout,
+} from "@lucide/astro";
 
 const posts: CollectionEntry<"feed">[] = (await getCollection("feed")).sort(
   (a, b) => b.data.order - a.data.order,
@@ -16,6 +29,19 @@ const featuredImage = featured ? firstPostImage(featured.slug) : undefined;
 
 const formatDate = (date: Date) =>
   date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+
+// Per-resource icon and a friendly domain label for each platform.
+const resourceIcons: Record<string, typeof Sprout> = {
+  "day-themes-menu": CalendarDays,
+  "google-books-list-multi-passionate": BookOpen,
+  "google-maps-list-tbilisi-art-spaces": MapPin,
+  "quick-tech-seo-checklist-new-websites": ListChecks,
+};
+const platformDomains: Record<string, string> = {
+  Notion: "notion.com",
+  "Google Books": "books.google.com",
+  "Google Maps": "maps.google.com",
+};
 ---
 
 <BaseLayout
@@ -45,7 +71,7 @@ const formatDate = (date: Date) =>
         <h2 class="text-xl font-semibold md:text-2xl">Home</h2>
         <span
           class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
-          >back home</span
+          >zmoki.xyz</span
         >
       </a>
 
@@ -76,111 +102,180 @@ const formatDate = (date: Date) =>
       </a>
     </div>
 
-    <!-- Posts -->
-    <section class="space-y-4">
-      <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">Posts</h2>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {
-          featured && (
-            <a
-              href={`/feed/${featured.slug}/`}
-              style={featuredImage ? `background-image:url(${featuredImage})` : undefined}
-              class:list={[
-                "group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2",
-                featuredImage ? "bg-cover bg-center text-slate-50" : "text-zmoki-ink",
-              ]}
-            >
-              {featuredImage && (
-                <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
-              )}
-              <div class="relative flex flex-col gap-2">
-                <p
-                  class:list={[
-                    "font-mono text-xs uppercase tracking-wider",
-                    featuredImage ? "text-zmoki-magenta-400" : "text-zmoki-magenta-500",
-                  ]}
-                >
-                  latest
-                </p>
-                <h3
-                  class="text-xl font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-2xl"
-                  set:html={featured.data.title}
-                />
-                <p class="text-sm opacity-90" set:html={featured.data.description} />
-                <p class="font-mono text-xs uppercase tracking-normal opacity-80">
-                  <time datetime={featured.data.contentModifiedDate.toISOString()}>
-                    {formatDate(featured.data.contentModifiedDate)}
-                  </time>
-                </p>
-              </div>
-            </a>
-          )
-        }
-        {
-          rest.map((post) => (
-            <a
-              href={`/feed/${post.slug}/`}
-              class="group flex flex-col gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
-            >
-              <h3
-                class="text-lg font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
-                set:html={post.data.title}
-              />
-              <p class="text-sm opacity-80" set:html={post.data.description} />
-              <p class="mt-auto font-mono text-xs uppercase tracking-normal text-zmoki-muted">
-                <time datetime={post.data.contentModifiedDate.toISOString()}>
-                  {formatDate(post.data.contentModifiedDate)}
-                </time>
-              </p>
-            </a>
-          ))
-        }
-      </div>
-    </section>
-
-    <!-- Resources -->
-    <section class="space-y-4">
-      <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">
-        Resources
-      </h2>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {
-          resources.map((resource) => {
-            const isLink = resource.data.type === "link";
-            const href = isLink ? resource.data.url : `/resources/${resource.slug}/`;
-            return (
+    <!-- Posts (3/4) + Resources (1/4) -->
+    <div class="grid gap-8 lg:grid-cols-4">
+      <!-- Posts -->
+      <section class="space-y-4 lg:col-span-3">
+        <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">Posts</h2>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:auto-rows-[200px] lg:grid-cols-3">
+          {
+            featured && (
               <a
-                href={href}
-                {...(isLink
-                  ? {
-                      target: "_blank",
-                      rel: "noopener noreferrer",
-                      "data-resource": "true",
-                      "data-resource-slug": resource.slug,
-                      "data-resource-external": "true",
-                    }
-                  : { "data-resource": "true", "data-resource-slug": resource.slug })}
-                class="group flex flex-col gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-jade-500/40"
+                href={`/feed/${featured.slug}/`}
+                style={featuredImage ? `background-image:url(${featuredImage})` : undefined}
+                class:list={[
+                  "group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2 lg:row-span-2",
+                  featuredImage ? "bg-cover bg-center text-slate-50" : "text-zmoki-ink",
+                ]}
               >
-                <p class="font-mono text-xs uppercase tracking-wider text-zmoki-jade-600">
-                  resource
-                </p>
+                {featuredImage && (
+                  <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
+                )}
+                <div class="relative flex flex-col gap-2">
+                  <p
+                    class:list={[
+                      "font-mono text-xs uppercase tracking-wider",
+                      featuredImage ? "text-zmoki-magenta-400" : "text-zmoki-magenta-500",
+                    ]}
+                  >
+                    latest
+                  </p>
+                  <h3
+                    class="text-xl font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-2xl"
+                    set:html={featured.data.title}
+                  />
+                  <p class="text-sm opacity-90" set:html={featured.data.description} />
+                  <p class="font-mono text-xs uppercase tracking-normal opacity-80">
+                    <time datetime={featured.data.contentModifiedDate.toISOString()}>
+                      {formatDate(featured.data.contentModifiedDate)}
+                    </time>
+                  </p>
+                </div>
+              </a>
+            )
+          }
+          {
+            rest.map((post) => (
+              <a
+                href={`/feed/${post.slug}/`}
+                class="group flex flex-col gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 lg:row-span-2"
+              >
                 <h3
                   class="text-lg font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
-                  set:html={resource.data.title}
+                  set:html={post.data.title}
                 />
-                <p class="text-sm opacity-80" set:html={resource.data.description} />
-                {resource.data.platform && (
-                  <p class="mt-auto font-mono text-sm text-zmoki-jade-600">
-                    {resource.data.platform.name}
-                  </p>
-                )}
+                <p class="line-clamp-3 text-sm opacity-80" set:html={post.data.description} />
+                <p class="mt-auto font-mono text-xs uppercase tracking-normal text-zmoki-muted">
+                  <time datetime={post.data.contentModifiedDate.toISOString()}>
+                    {formatDate(post.data.contentModifiedDate)}
+                  </time>
+                </p>
               </a>
-            );
-          })
-        }
-      </div>
-    </section>
+            ))
+          }
+        </div>
+      </section>
+
+      <!-- Resources -->
+      <section class="space-y-4">
+        <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">
+          Resources
+        </h2>
+        <div class="grid grid-cols-1 gap-4 lg:auto-rows-[200px]">
+          {
+            resources.map((resource) => {
+              const isLink = resource.data.type === "link";
+              const href = isLink ? resource.data.url : `/resources/${resource.slug}/`;
+              const Icon = resourceIcons[resource.slug] ?? Link;
+              const domain = resource.data.platform
+                ? (platformDomains[resource.data.platform.name] ?? resource.data.platform.name)
+                : undefined;
+              return (
+                <a
+                  href={href}
+                  {...(isLink
+                    ? {
+                        target: "_blank",
+                        rel: "noopener noreferrer",
+                        "data-resource": "true",
+                        "data-resource-slug": resource.slug,
+                        "data-resource-external": "true",
+                      }
+                    : { "data-resource": "true", "data-resource-slug": resource.slug })}
+                  class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-jade-500/40 lg:row-span-2"
+                >
+                  <Icon class="h-6 w-6 text-zmoki-jade-600" />
+                  <h3
+                    class="text-lg font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+                    set:html={resource.data.title}
+                  />
+                  <p class="text-sm opacity-80" set:html={resource.data.description} />
+                  {domain && (
+                    <span class="font-mono text-sm text-zmoki-jade-600 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline">
+                      {domain}
+                    </span>
+                  )}
+                </a>
+              );
+            })
+          }
+        </div>
+      </section>
+    </div>
+
+    <!-- Footer bento -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:auto-rows-[200px] lg:grid-cols-4">
+      <!-- Source code -->
+      <a
+        href="https://github.com/Zmoki/zmoki.xyz"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
+      >
+        <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >github.com</span
+        >
+      </a>
+
+      <!-- Design system -->
+      <a
+        href="/-/astro/brand/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Palette class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Design system</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >brand</span
+        >
+      </a>
+
+      <!-- Legal -->
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <Scale class="h-6 w-6 text-zmoki-muted" />
+        <h2 class="text-xl font-semibold md:text-2xl">Legal</h2>
+        <p class="flex flex-wrap gap-4">
+          <a
+            href="/legal/privacy/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >policy</a
+          >
+          <a
+            href="/legal/terms/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >terms</a
+          >
+        </p>
+      </article>
+
+      <!-- Home -->
+      <a
+        href="/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Home class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Home</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >zmoki.xyz</span
+        >
+      </a>
+    </div>
   </main>
 
   <script is:inline>

--- a/src/pages/garden.astro
+++ b/src/pages/garden.astro
@@ -1,0 +1,201 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import { firstPostImage } from "@/utils/post-image";
+import { Activity, Home, Mail, Sprout } from "@lucide/astro";
+
+const posts: CollectionEntry<"feed">[] = (await getCollection("feed")).sort(
+  (a, b) => b.data.order - a.data.order,
+);
+const resources: CollectionEntry<"resources">[] = (await getCollection("resources")).sort(
+  (a, b) => a.data.order - b.data.order,
+);
+
+const [featured, ...rest] = posts;
+const featuredImage = featured ? firstPostImage(featured.slug) : undefined;
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+---
+
+<BaseLayout
+  title="The digital garden — Zarema Khalilova"
+  description="Essays, deep dives, and resources where my interests connect — software, art, and neurodivergent research."
+>
+  <main class="space-y-8 p-2 lg:p-4">
+    <!-- Header bento -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:auto-rows-[200px] lg:grid-cols-4">
+      <!-- The digital garden — 2x2 -->
+      <article
+        class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md sm:col-span-2 lg:row-span-2"
+      >
+        <Sprout class="h-10 w-10 text-zmoki-magenta-500" />
+        <h1 class="text-4xl font-semibold text-zmoki-magenta-500 md:text-5xl">Digital Garden</h1>
+        <p class="text-lg md:text-xl">
+          A living collection of creative projects and deep dives where all my interests connect.
+        </p>
+      </article>
+
+      <!-- Back to home — 1x1 -->
+      <a
+        href="/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Home class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Home</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >back home</span
+        >
+      </a>
+
+      <!-- Right now — 1x1 -->
+      <a
+        href="/now/"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+      >
+        <Activity class="h-6 w-6 text-zmoki-magenta-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+          >now</span
+        >
+      </a>
+
+      <!-- Say hi — 2x1 -->
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40 sm:col-span-2"
+      >
+        <Mail class="h-6 w-6 text-zmoki-flame-500" />
+        <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
+        <span
+          class="font-mono text-2xl text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-3xl"
+          >hey@zmoki.xyz</span
+        >
+      </a>
+    </div>
+
+    <!-- Posts -->
+    <section class="space-y-4">
+      <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">Posts</h2>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {
+          featured && (
+            <a
+              href={`/feed/${featured.slug}/`}
+              style={featuredImage ? `background-image:url(${featuredImage})` : undefined}
+              class:list={[
+                "group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2",
+                featuredImage ? "bg-cover bg-center text-slate-50" : "text-zmoki-ink",
+              ]}
+            >
+              {featuredImage && (
+                <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
+              )}
+              <div class="relative flex flex-col gap-2">
+                <p
+                  class:list={[
+                    "font-mono text-xs uppercase tracking-wider",
+                    featuredImage ? "text-zmoki-magenta-400" : "text-zmoki-magenta-500",
+                  ]}
+                >
+                  latest
+                </p>
+                <h3
+                  class="text-xl font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-2xl"
+                  set:html={featured.data.title}
+                />
+                <p class="text-sm opacity-90" set:html={featured.data.description} />
+                <p class="font-mono text-xs uppercase tracking-normal opacity-80">
+                  <time datetime={featured.data.contentModifiedDate.toISOString()}>
+                    {formatDate(featured.data.contentModifiedDate)}
+                  </time>
+                </p>
+              </div>
+            </a>
+          )
+        }
+        {
+          rest.map((post) => (
+            <a
+              href={`/feed/${post.slug}/`}
+              class="group flex flex-col gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
+            >
+              <h3
+                class="text-lg font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+                set:html={post.data.title}
+              />
+              <p class="text-sm opacity-80" set:html={post.data.description} />
+              <p class="mt-auto font-mono text-xs uppercase tracking-normal text-zmoki-muted">
+                <time datetime={post.data.contentModifiedDate.toISOString()}>
+                  {formatDate(post.data.contentModifiedDate)}
+                </time>
+              </p>
+            </a>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Resources -->
+    <section class="space-y-4">
+      <h2 class="text-center font-mono text-3xl uppercase tracking-normal md:text-4xl">
+        Resources
+      </h2>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {
+          resources.map((resource) => {
+            const isLink = resource.data.type === "link";
+            const href = isLink ? resource.data.url : `/resources/${resource.slug}/`;
+            return (
+              <a
+                href={href}
+                {...(isLink
+                  ? {
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      "data-resource": "true",
+                      "data-resource-slug": resource.slug,
+                      "data-resource-external": "true",
+                    }
+                  : { "data-resource": "true", "data-resource-slug": resource.slug })}
+                class="group flex flex-col gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-jade-500/40"
+              >
+                <p class="font-mono text-xs uppercase tracking-wider text-zmoki-jade-600">
+                  resource
+                </p>
+                <h3
+                  class="text-lg font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+                  set:html={resource.data.title}
+                />
+                <p class="text-sm opacity-80" set:html={resource.data.description} />
+                {resource.data.platform && (
+                  <p class="mt-auto font-mono text-sm text-zmoki-jade-600">
+                    {resource.data.platform.name}
+                  </p>
+                )}
+              </a>
+            );
+          })
+        }
+      </div>
+    </section>
+  </main>
+
+  <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+    document.querySelectorAll('a[data-resource="true"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("resource_link_clicked", {
+          resource_slug: this.dataset.resourceSlug,
+          is_external: this.dataset.resourceExternal === "true",
+        });
+      });
+    });
+  </script>
+</BaseLayout>

--- a/src/pages/garden.astro
+++ b/src/pages/garden.astro
@@ -28,7 +28,7 @@ const resources: CollectionEntry<"resources">[] = (await getCollection("resource
 );
 
 const [featured, ...rest] = posts;
-const featuredImage = featured ? firstPostImage(featured.slug) : undefined;
+const featuredImage = featured ? await firstPostImage(featured.slug) : undefined;
 
 const formatDate = (date: Date) =>
   date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });

--- a/src/pages/garden.astro
+++ b/src/pages/garden.astro
@@ -17,6 +17,9 @@ import {
   Sprout,
 } from "@lucide/astro";
 
+export const publishDate = new Date("2026-06-29");
+export const contentModifiedDate = new Date("2026-06-29");
+
 const posts: CollectionEntry<"feed">[] = (await getCollection("feed")).sort(
   (a, b) => b.data.order - a.data.order,
 );
@@ -279,9 +282,11 @@ const platformDomains: Record<string, string> = {
   </main>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
       });
     });
     document.querySelectorAll('a[data-resource="true"]').forEach(function (el) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ import {
 } from "@lucide/astro";
 
 export const publishDate = new Date("2025-09-09");
-export const contentModifiedDate = new Date("2026-06-20");
+export const contentModifiedDate = new Date("2026-06-29");
 
 const allPosts: CollectionEntry<"feed">[] = await getCollection("feed");
 // Match by the leading number in the filename/slug (e.g. "6-tbilisi-swaps-guide")
@@ -280,9 +280,19 @@ const dayThemesImage = imageUrl("/src/images/screenshot-notion-day-themes.png");
   </main>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
+      });
+    });
+    document.querySelectorAll('a[data-resource="true"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("resource_link_clicked", {
+          resource_slug: this.dataset.resourceSlug,
+          is_external: this.dataset.resourceExternal === "true",
+        });
       });
     });
   </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -200,7 +200,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
           <a
             href={`/feed/${post1.slug}/`}
             style={post1Image ? `background-image:url(${post1Image})` : undefined}
-            class="group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface bg-cover bg-center p-6 text-slate-50 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-azure-500/40 sm:col-span-2 lg:row-span-2"
+            class="group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface bg-cover bg-center p-6 text-slate-50 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2 lg:row-span-2"
           >
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
             <div class="relative flex flex-col gap-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection, getEntry, type CollectionEntry } from "astro:content";
-import type { ImageMetadata } from "astro";
+import { firstPostImage, imageUrl } from "@/utils/post-image";
 import {
   Activity,
   Briefcase,
@@ -26,33 +26,8 @@ const post1 = postByNumber(1);
 
 const dayThemes = await getEntry("resources", "day-themes-menu");
 
-// Resolve the first <PostImage> used in a post and return its optimized URL,
-// so a post card can use the post's own photo as a background.
-const postSources = import.meta.glob("/src/content/feed/*.{md,mdx}", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
-const imageAssets = import.meta.glob("/src/images/*.{jpg,jpeg,png,webp,avif}", {
-  eager: true,
-}) as Record<string, { default: ImageMetadata }>;
-
-function firstPostImage(slug: string): string | undefined {
-  const sourceKey = Object.keys(postSources).find(
-    (key) => key.endsWith(`/${slug}.mdx`) || key.endsWith(`/${slug}.md`),
-  );
-  if (!sourceKey) return undefined;
-  const source = postSources[sourceKey];
-  const usage = source.match(/<PostImage[^>]*\bsrc=\{(\w+)\}/);
-  if (!usage) return undefined;
-  const importMatch = source.match(new RegExp(`import\\s+${usage[1]}\\s+from\\s+["']([^"']+)["']`));
-  if (!importMatch) return undefined;
-  const assetKey = importMatch[1].replace("@/images/", "/src/images/");
-  return imageAssets[assetKey]?.default.src;
-}
-
 const post1Image = post1 ? firstPostImage(post1.slug) : undefined;
-const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png"]?.default.src;
+const dayThemesImage = imageUrl("/src/images/screenshot-notion-day-themes.png");
 ---
 
 <BaseLayout
@@ -130,7 +105,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2"
       >
         <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
-        <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
+        <h2 class="text-xl font-semibold md:text-2xl">Digital Garden</h2>
         <p class="text-base md:text-lg">Essays and deep dives where my interests connect.</p>
         <span
           class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,48 +1,231 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import PostCard from "@/components/PostCard.astro";
-import { getCollection, type CollectionEntry } from "astro:content";
+import { getCollection, getEntry, type CollectionEntry } from "astro:content";
 
 export const publishDate = new Date("2025-09-09");
 export const contentModifiedDate = new Date("2026-06-20");
 
-// Get all posts from the feed collection
 const allPosts: CollectionEntry<"feed">[] = await getCollection("feed");
+// Match by the leading number in the filename/slug (e.g. "6-tbilisi-swaps-guide")
+const postByNumber = (n: number) => allPosts.find((post) => post.slug.startsWith(`${n}-`));
+const post1 = postByNumber(1);
+const post6 = postByNumber(6);
 
-// Sort posts by publish date (newest first)
-const sortedPosts = allPosts.sort((a, b) => b.data.order - a.data.order);
+const dayThemes = await getEntry("resources", "day-themes-menu");
 ---
 
 <BaseLayout
   title="Digital Garden of Zarema Khalilova"
   description="A personal collection of art, research, and creative projects from a neurodivergent developer and artist. A space for curiosity, not a niche."
-  showRecentPosts={false}
-  accentColor="blue"
 >
-  <!-- Hero Section -->
-  <section
-    class="mb-4 space-y-4 rounded-xl bg-zmoki-azure-500 px-4 py-8 text-slate-50 shadow-md md:px-8 md:py-16 lg:py-20"
-  >
-    <h1 class="mb-6 text-6xl font-semibold md:text-7xl">Digital Garden</h1>
-    <p class="text-2xl md:text-3xl">
-      A living collection of creative projects and deep dives where all my interests connect.
-    </p>
-  </section>
+  <main class="p-2 lg:p-4">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:auto-rows-[200px] lg:grid-cols-4">
+      <!-- Card 1 — 2x2 -->
+      <article
+        class="flex flex-col justify-center gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md sm:col-span-2 lg:row-span-2"
+      >
+        <img
+          src="/zmoki.jpg"
+          alt="Zarema Khalilova"
+          width="112"
+          height="112"
+          class="h-28 w-28 rounded-full object-cover"
+        />
+        <h1 class="text-4xl font-semibold text-zmoki-magenta-500 md:text-5xl">Zarema Khalilova</h1>
+        <p class="text-xl md:text-2xl">
+          I build things, I make art, and I think out loud. Engineer, contemporary artist, data
+          person, all the same person. This is where every side lives.
+        </p>
+      </article>
 
-  <!-- Posts List -->
-  <section class="pt-2 md:pt-4">
-    <h2 class="px-4 pb-8 text-5xl font-semibold md:px-8 md:text-6xl">Posts</h2>
+      <!-- Card 2 — 1x2 -->
+      <a
+        href="https://tech.zarema.me/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-azure-500 p-8 text-slate-50 shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">The technical half</h2>
+        <p class="text-base md:text-lg">
+          As a Marketing Technologist I help marketers with engineering stuff.
+        </p>
+        <span class="font-mono text-sm">tech.zarema.me</span>
+      </a>
 
-    {
-      sortedPosts.length === 0 ? (
-        <p>No posts yet. Check back soon!</p>
-      ) : (
-        <div class="grid grid-flow-dense grid-cols-1 gap-6">
-          {sortedPosts.map((post: CollectionEntry<"feed">) => (
-            <PostCard {...post} />
-          ))}
-        </div>
-      )
-    }
-  </section>
+      <!-- Card 4 — 1x1 -->
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Based in</h2>
+        <p class="text-sm md:text-base">Tbilisi, Georgia</p>
+      </article>
+
+      <!-- Card 3 — 1x1 -->
+      <a
+        href="/now/"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-magenta-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
+        <p class="text-sm md:text-base">GoodINP, websites migration, paper collages</p>
+        <span class="font-mono text-sm">now</span>
+      </a>
+
+      <!-- Card 5 — 1x1 -->
+      <article
+        class="flex flex-col items-center justify-center gap-1 rounded-xl bg-zmoki-surface p-6 text-center text-zmoki-ink shadow-md"
+      >
+        <span class="text-5xl font-semibold text-zmoki-azure-500 md:text-6xl">2004</span>
+        <p class="text-sm md:text-base">my first website</p>
+      </article>
+
+      <!-- Card 6 — 1x1 -->
+      <article
+        class="flex flex-col items-center justify-center gap-1 rounded-xl bg-zmoki-surface p-6 text-center text-zmoki-ink shadow-md"
+      >
+        <span class="text-5xl font-semibold text-zmoki-flame-500 md:text-6xl">2023</span>
+        <p class="text-sm md:text-base">my first art exhibition</p>
+      </article>
+
+      <!-- Card 7 — 2x1 -->
+      <a
+        href="/garden/"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-flame-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
+        <p class="text-sm md:text-base">
+          Essays and deep dives where my interests connect. Read everything here.
+        </p>
+        <span class="font-mono text-sm">garden</span>
+      </a>
+
+      <!-- Card 8 — 2x1 — preview of post #1 -->
+      {
+        post1 && (
+          <a
+            href={`/feed/${post1.slug}/`}
+            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+          >
+            <p class="font-mono text-xs uppercase tracking-normal opacity-70">
+              <time datetime={post1.data.contentModifiedDate.toISOString()}>
+                {post1.data.contentModifiedDate.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+            </p>
+            <h2 class="text-xl font-semibold md:text-2xl" set:html={post1.data.title} />
+            <p class="text-sm opacity-80 md:text-base" set:html={post1.data.description} />
+          </a>
+        )
+      }
+
+      <!-- Card 9 — 1x1 -->
+      <a
+        href="https://www.linkedin.com/in/zaremakhalilova/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-azure-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
+        <p class="text-sm md:text-base">the work side</p>
+      </a>
+
+      <!-- Card 10 — 1x2 — Day Themes Notion template resource -->
+      {
+        dayThemes && dayThemes.data.type === "link" && (
+          <a
+            href={dayThemes.data.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-resource="true"
+            data-resource-slug={dayThemes.slug}
+            data-resource-external="true"
+            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-jade-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+          >
+            <h2 class="text-xl font-semibold md:text-2xl" set:html={dayThemes.data.title} />
+            <p class="text-sm opacity-90 md:text-base" set:html={dayThemes.data.description} />
+            <span class="font-mono text-sm">notion.com</span>
+          </a>
+        )
+      }
+
+      <!-- Card 11 — 2x1 — preview of post #6 -->
+      {
+        post6 && (
+          <a
+            href={`/feed/${post6.slug}/`}
+            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+          >
+            <p class="font-mono text-xs uppercase tracking-normal opacity-70">
+              <time datetime={post6.data.contentModifiedDate.toISOString()}>
+                {post6.data.contentModifiedDate.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+            </p>
+            <h2 class="text-xl font-semibold md:text-2xl" set:html={post6.data.title} />
+            <p class="text-sm opacity-80 md:text-base" set:html={post6.data.description} />
+          </a>
+        )
+      }
+
+      <!-- Card 12 — 1x1 -->
+      <a
+        href="https://www.instagram.com/zmoki/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-magenta-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
+        <p class="text-sm md:text-base">the visual side</p>
+      </a>
+
+      <!-- Card 13 — 1x1 -->
+      <a
+        href="https://github.com/Zmoki/zmoki.xyz"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-slate-700 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
+        <p class="text-sm md:text-base">this site on GitHub</p>
+        <span class="font-mono text-sm">github.com</span>
+      </a>
+
+      <!-- Card 14 — 2x1 -->
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-flame-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
+        <p class="text-sm md:text-base">hey@zmoki.xyz</p>
+      </a>
+
+      <!-- Card 15 — 1x1 -->
+      <article
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Legal</h2>
+        <p class="flex flex-col gap-1 text-sm md:text-base">
+          <a href="/legal/privacy/" class="w-fit border-b-2 border-dotted border-current"
+            >Privacy Policy</a
+          >
+          <a href="/legal/terms/" class="w-fit border-b-2 border-dotted border-current"
+            >Terms of Service</a
+          >
+        </p>
+      </article>
+    </div>
+  </main>
+
+  <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+  </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,9 +56,7 @@ const dayThemesImage = imageUrl("/src/images/screenshot-notion-day-themes.png");
 
       <!-- Card 2 — 1x2 -->
       <a
-        href="https://tech.zarema.me/"
-        target="_blank"
-        rel="noopener noreferrer"
+        href="/tech/"
         class="group flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-azure-500/40 lg:row-span-2"
       >
         <Code class="h-6 w-6 text-zmoki-azure-500" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection, getEntry, type CollectionEntry } from "astro:content";
+import type { ImageMetadata } from "astro";
 
 export const publishDate = new Date("2025-09-09");
 export const contentModifiedDate = new Date("2026-06-20");
@@ -9,9 +10,36 @@ const allPosts: CollectionEntry<"feed">[] = await getCollection("feed");
 // Match by the leading number in the filename/slug (e.g. "6-tbilisi-swaps-guide")
 const postByNumber = (n: number) => allPosts.find((post) => post.slug.startsWith(`${n}-`));
 const post1 = postByNumber(1);
-const post6 = postByNumber(6);
 
 const dayThemes = await getEntry("resources", "day-themes-menu");
+
+// Resolve the first <PostImage> used in a post and return its optimized URL,
+// so a post card can use the post's own photo as a background.
+const postSources = import.meta.glob("/src/content/feed/*.{md,mdx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+const imageAssets = import.meta.glob("/src/images/*.{jpg,jpeg,png,webp,avif}", {
+  eager: true,
+}) as Record<string, { default: ImageMetadata }>;
+
+function firstPostImage(slug: string): string | undefined {
+  const sourceKey = Object.keys(postSources).find(
+    (key) => key.endsWith(`/${slug}.mdx`) || key.endsWith(`/${slug}.md`),
+  );
+  if (!sourceKey) return undefined;
+  const source = postSources[sourceKey];
+  const usage = source.match(/<PostImage[^>]*\bsrc=\{(\w+)\}/);
+  if (!usage) return undefined;
+  const importMatch = source.match(new RegExp(`import\\s+${usage[1]}\\s+from\\s+["']([^"']+)["']`));
+  if (!importMatch) return undefined;
+  const assetKey = importMatch[1].replace("@/images/", "/src/images/");
+  return imageAssets[assetKey]?.default.src;
+}
+
+const post1Image = post1 ? firstPostImage(post1.slug) : undefined;
+const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png"]?.default.src;
 ---
 
 <BaseLayout
@@ -43,92 +71,59 @@ const dayThemes = await getEntry("resources", "day-themes-menu");
         href="https://tech.zarema.me/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-azure-500 p-8 text-slate-50 shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+        class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
       >
         <h2 class="text-xl font-semibold md:text-2xl">The technical half</h2>
         <p class="text-base md:text-lg">
           As a Marketing Technologist I help marketers with engineering stuff.
         </p>
-        <span class="font-mono text-sm">tech.zarema.me</span>
+        <span class="font-mono text-sm text-zmoki-azure-500">tech</span>
       </a>
 
-      <!-- Card 4 — 1x1 -->
+      <!-- Card 4 — 1x1 — Based in -->
       <article
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
       >
         <h2 class="text-xl font-semibold md:text-2xl">Based in</h2>
-        <p class="text-sm md:text-base">Tbilisi, Georgia</p>
+        <p class="text-sm md:text-base">
+          <mark class="bg-zmoki-lemon box-decoration-clone px-1 text-zmoki-ink"
+            >Tbilisi, Georgia</mark
+          >
+        </p>
       </article>
 
-      <!-- Card 3 — 1x1 -->
+      <!-- Card 3 — 1x1 — Right now -->
       <a
         href="/now/"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-magenta-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
         <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
         <p class="text-sm md:text-base">GoodINP, websites migration, paper collages</p>
-        <span class="font-mono text-sm">now</span>
+        <span class="font-mono text-sm text-zmoki-magenta-500">now</span>
       </a>
 
-      <!-- Card 5 — 1x1 -->
-      <article
-        class="flex flex-col items-center justify-center gap-1 rounded-xl bg-zmoki-surface p-6 text-center text-zmoki-ink shadow-md"
-      >
-        <span class="text-5xl font-semibold text-zmoki-azure-500 md:text-6xl">2004</span>
-        <p class="text-sm md:text-base">my first website</p>
-      </article>
-
-      <!-- Card 6 — 1x1 -->
-      <article
-        class="flex flex-col items-center justify-center gap-1 rounded-xl bg-zmoki-surface p-6 text-center text-zmoki-ink shadow-md"
-      >
-        <span class="text-5xl font-semibold text-zmoki-flame-500 md:text-6xl">2023</span>
-        <p class="text-sm md:text-base">my first art exhibition</p>
-      </article>
-
-      <!-- Card 7 — 2x1 -->
+      <!-- Card 7 — 2x1 — The digital garden -->
       <a
         href="/garden/"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-flame-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
         <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
         <p class="text-sm md:text-base">
           Essays and deep dives where my interests connect. Read everything here.
         </p>
-        <span class="font-mono text-sm">garden</span>
+        <span class="font-mono text-sm text-zmoki-magenta-500">garden</span>
       </a>
 
-      <!-- Card 8 — 2x1 — preview of post #1 -->
-      {
-        post1 && (
-          <a
-            href={`/feed/${post1.slug}/`}
-            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
-          >
-            <p class="font-mono text-xs uppercase tracking-normal opacity-70">
-              <time datetime={post1.data.contentModifiedDate.toISOString()}>
-                {post1.data.contentModifiedDate.toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </time>
-            </p>
-            <h2 class="text-xl font-semibold md:text-2xl" set:html={post1.data.title} />
-            <p class="text-sm opacity-80 md:text-base" set:html={post1.data.description} />
-          </a>
-        )
-      }
-
-      <!-- Card 9 — 1x1 -->
+      <!-- Card 12 — 1x1 — Instagram -->
       <a
-        href="https://www.linkedin.com/in/zaremakhalilova/"
+        href="https://www.instagram.com/zmoki/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-azure-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
-        <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
-        <p class="text-sm md:text-base">the work side</p>
+        <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
+        <p class="text-sm md:text-base">the visual side</p>
+        <span class="font-mono text-sm text-zmoki-magenta-500">@zmoki</span>
       </a>
 
       <!-- Card 10 — 1x2 — Day Themes Notion template resource -->
@@ -141,81 +136,103 @@ const dayThemes = await getEntry("resources", "day-themes-menu");
             data-resource="true"
             data-resource-slug={dayThemes.slug}
             data-resource-external="true"
-            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-jade-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+            class="relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
           >
-            <h2 class="text-xl font-semibold md:text-2xl" set:html={dayThemes.data.title} />
-            <p class="text-sm opacity-90 md:text-base" set:html={dayThemes.data.description} />
-            <span class="font-mono text-sm">notion.com</span>
+            {dayThemesImage && (
+              <img
+                src={dayThemesImage}
+                alt=""
+                aria-hidden="true"
+                class="absolute inset-0 h-full w-full -translate-x-6 -rotate-6 scale-125 object-cover"
+              />
+            )}
+            <div class="absolute inset-0 bg-gradient-to-t from-zmoki-surface/95 via-zmoki-surface/60 to-zmoki-surface/10" />
+            <div class="relative flex flex-col gap-2">
+              <h2 class="text-xl font-semibold md:text-2xl" set:html={dayThemes.data.title} />
+              <p class="text-sm opacity-90 md:text-base" set:html={dayThemes.data.description} />
+              <span class="font-mono text-sm text-zmoki-jade-600">notion.com</span>
+            </div>
           </a>
         )
       }
 
-      <!-- Card 11 — 2x1 — preview of post #6 -->
+      <!-- Card 8 — 2x2 — preview of post #1 -->
       {
-        post6 && (
+        post1 && (
           <a
-            href={`/feed/${post6.slug}/`}
-            class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+            href={`/feed/${post1.slug}/`}
+            style={post1Image ? `background-image:url(${post1Image})` : undefined}
+            class="relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface bg-cover bg-center p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2 lg:row-span-2"
           >
-            <p class="font-mono text-xs uppercase tracking-normal opacity-70">
-              <time datetime={post6.data.contentModifiedDate.toISOString()}>
-                {post6.data.contentModifiedDate.toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </time>
-            </p>
-            <h2 class="text-xl font-semibold md:text-2xl" set:html={post6.data.title} />
-            <p class="text-sm opacity-80 md:text-base" set:html={post6.data.description} />
+            <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
+            <div class="relative flex flex-col gap-2">
+              <p class="font-mono text-xs uppercase tracking-normal opacity-80">
+                <time datetime={post1.data.contentModifiedDate.toISOString()}>
+                  {post1.data.contentModifiedDate.toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+              </p>
+              <h2 class="text-xl font-semibold md:text-2xl" set:html={post1.data.title} />
+              <p class="text-sm opacity-90 md:text-base" set:html={post1.data.description} />
+            </div>
           </a>
         )
       }
 
-      <!-- Card 12 — 1x1 -->
+      <!-- Card 9 — 1x1 — LinkedIn -->
       <a
-        href="https://www.instagram.com/zmoki/"
+        href="https://www.linkedin.com/in/zaremakhalilova/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-magenta-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
-        <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
-        <p class="text-sm md:text-base">the visual side</p>
+        <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
+        <p class="text-sm md:text-base">the work side</p>
+        <span class="font-mono text-sm text-zmoki-azure-500">@zaremakhalilova</span>
       </a>
 
-      <!-- Card 13 — 1x1 -->
+      <!-- Card 14 — 2x1 — Say hi -->
+      <a
+        href="mailto:hey@zmoki.xyz"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+      >
+        <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
+        <span class="font-mono text-2xl text-zmoki-flame-500 md:text-3xl">hey@zmoki.xyz</span>
+      </a>
+
+      <!-- Card 13 — 1x1 — Source code -->
       <a
         href="https://github.com/Zmoki/zmoki.xyz"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-slate-700 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
         <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
         <p class="text-sm md:text-base">this site on GitHub</p>
-        <span class="font-mono text-sm">github.com</span>
+        <span class="font-mono text-sm text-zmoki-flame-500">github.com</span>
       </a>
 
-      <!-- Card 14 — 2x1 -->
+      <!-- Card 16 — 2x1 — Design system -->
       <a
-        href="mailto:hey@zmoki.xyz"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-flame-500 p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+        href="/-/astro/brand/"
+        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
-        <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
-        <p class="text-sm md:text-base">hey@zmoki.xyz</p>
+        <h2 class="text-xl font-semibold md:text-2xl">Design system</h2>
+        <p class="text-sm md:text-base">colors, type, components</p>
+        <span class="font-mono text-sm text-zmoki-magenta-500">brand</span>
       </a>
 
-      <!-- Card 15 — 1x1 -->
+      <!-- Card 15 — 1x1 — Legal -->
       <article
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
       >
         <h2 class="text-xl font-semibold md:text-2xl">Legal</h2>
-        <p class="flex flex-col gap-1 text-sm md:text-base">
-          <a href="/legal/privacy/" class="w-fit border-b-2 border-dotted border-current"
-            >Privacy Policy</a
-          >
-          <a href="/legal/terms/" class="w-fit border-b-2 border-dotted border-current"
-            >Terms of Service</a
-          >
+        <p class="flex flex-col gap-1">
+          <a href="/legal/privacy/" class="w-fit font-mono text-sm text-zmoki-muted">policy</a>
+          <a href="/legal/terms/" class="w-fit font-mono text-sm text-zmoki-muted">terms</a>
         </p>
       </article>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,7 +85,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="https://tech.zarema.me/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+        class="group flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-azure-500/40 lg:row-span-2"
       >
         <Code class="h-6 w-6 text-zmoki-azure-500" />
         <h2 class="text-xl font-semibold md:text-2xl">The technical half</h2>
@@ -93,7 +93,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
           As a Marketing Technologist I help marketers with engineering stuff.
         </p>
         <span
-          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >tech</span
         >
       </a>
@@ -114,13 +114,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <!-- Card 3 — 1x1 — Right now -->
       <a
         href="/now/"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
       >
         <Activity class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
         <p class="text-sm md:text-base">GoodINP, websites migration, paper collages</p>
         <span
-          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >now</span
         >
       </a>
@@ -128,13 +128,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <!-- Card 7 — 2x1 — The digital garden -->
       <a
         href="/garden/"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2"
       >
         <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
         <p class="text-base md:text-lg">Essays and deep dives where my interests connect.</p>
         <span
-          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >garden</span
         >
       </a>
@@ -144,13 +144,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="https://www.instagram.com/zmoki/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40"
       >
         <Camera class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
         <p class="text-sm md:text-base">the visual side</p>
         <span
-          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >@zmoki</span
         >
       </a>
@@ -165,7 +165,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
             data-resource="true"
             data-resource-slug={dayThemes.slug}
             data-resource-external="true"
-            class="relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
+            class="group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-jade-500/40 lg:row-span-2"
           >
             {dayThemesImage && (
               <img
@@ -186,7 +186,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
                 class="text-sm opacity-90 md:text-base"
                 set:html={dayThemes.data.description.split(". ")[0] + "."}
               />
-              <span class="font-mono text-sm text-zmoki-jade-600 underline decoration-dotted decoration-2 underline-offset-4">
+              <span class="font-mono text-sm text-zmoki-jade-600 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline">
                 notion.com
               </span>
             </div>
@@ -200,7 +200,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
           <a
             href={`/feed/${post1.slug}/`}
             style={post1Image ? `background-image:url(${post1Image})` : undefined}
-            class="relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface bg-cover bg-center p-6 text-slate-50 shadow-md transition-transform hover:-translate-y-1 sm:col-span-2 lg:row-span-2"
+            class="group relative flex flex-col justify-end gap-2 overflow-hidden rounded-xl bg-zmoki-surface bg-cover bg-center p-6 text-slate-50 shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-azure-500/40 sm:col-span-2 lg:row-span-2"
           >
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
             <div class="relative flex flex-col gap-2">
@@ -226,13 +226,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="https://www.linkedin.com/in/zaremakhalilova/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-azure-500/40"
       >
         <Briefcase class="h-6 w-6 text-zmoki-azure-500" />
         <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
         <p class="text-sm md:text-base">the work side</p>
         <span
-          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >@zaremakhalilova</span
         >
       </a>
@@ -240,12 +240,12 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <!-- Card 14 — 2x1 — Say hi -->
       <a
         href="mailto:hey@zmoki.xyz"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40 sm:col-span-2"
       >
         <Mail class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
         <span
-          class="font-mono text-2xl text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 md:text-3xl"
+          class="font-mono text-2xl text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-3xl"
           >hey@zmoki.xyz</span
         >
       </a>
@@ -255,13 +255,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="https://github.com/Zmoki/zmoki.xyz"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-flame-500/40"
       >
         <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
         <p class="text-sm md:text-base">this site on GitHub</p>
         <span
-          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >github.com</span
         >
       </a>
@@ -269,13 +269,13 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <!-- Card 16 — 2x1 — Design system -->
       <a
         href="/-/astro/brand/"
-        class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
+        class="group flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition hover:-translate-y-1 hover:shadow-xl hover:shadow-zmoki-magenta-500/40 sm:col-span-2"
       >
         <Palette class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Design system</h2>
         <p class="text-sm md:text-base">colors, type, components</p>
         <span
-          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
           >brand</span
         >
       </a>
@@ -289,12 +289,12 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <p class="flex flex-col gap-1">
           <a
             href="/legal/privacy/"
-            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
             >policy</a
           >
           <a
             href="/legal/terms/"
-            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
             >terms</a
           >
         </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,7 +92,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <p class="text-base md:text-lg">
           As a Marketing Technologist I help marketers with engineering stuff.
         </p>
-        <span class="font-mono text-sm text-zmoki-azure-500">tech</span>
+        <span
+          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >tech</span
+        >
       </a>
 
       <!-- Card 4 — 1x1 — Based in -->
@@ -116,7 +119,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Activity class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
         <p class="text-sm md:text-base">GoodINP, websites migration, paper collages</p>
-        <span class="font-mono text-sm text-zmoki-magenta-500">now</span>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >now</span
+        >
       </a>
 
       <!-- Card 7 — 2x1 — The digital garden -->
@@ -127,7 +133,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
         <p class="text-base md:text-lg">Essays and deep dives where my interests connect.</p>
-        <span class="font-mono text-sm text-zmoki-magenta-500">garden</span>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >garden</span
+        >
       </a>
 
       <!-- Card 12 — 1x1 — Instagram -->
@@ -140,7 +149,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Camera class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
         <p class="text-sm md:text-base">the visual side</p>
-        <span class="font-mono text-sm text-zmoki-magenta-500">@zmoki</span>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >@zmoki</span
+        >
       </a>
 
       <!-- Card 10 — 1x2 — Day Themes Notion template resource -->
@@ -174,7 +186,9 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
                 class="text-sm opacity-90 md:text-base"
                 set:html={dayThemes.data.description.split(". ")[0] + "."}
               />
-              <span class="font-mono text-sm text-zmoki-jade-600">notion.com</span>
+              <span class="font-mono text-sm text-zmoki-jade-600 underline decoration-dotted decoration-2 underline-offset-4">
+                notion.com
+              </span>
             </div>
           </a>
         )
@@ -217,7 +231,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Briefcase class="h-6 w-6 text-zmoki-azure-500" />
         <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
         <p class="text-sm md:text-base">the work side</p>
-        <span class="font-mono text-sm text-zmoki-azure-500">@zaremakhalilova</span>
+        <span
+          class="font-mono text-sm text-zmoki-azure-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >@zaremakhalilova</span
+        >
       </a>
 
       <!-- Card 14 — 2x1 — Say hi -->
@@ -227,7 +244,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       >
         <Mail class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
-        <span class="font-mono text-2xl text-zmoki-flame-500 md:text-3xl">hey@zmoki.xyz</span>
+        <span
+          class="font-mono text-2xl text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 md:text-3xl"
+          >hey@zmoki.xyz</span
+        >
       </a>
 
       <!-- Card 13 — 1x1 — Source code -->
@@ -240,7 +260,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
         <p class="text-sm md:text-base">this site on GitHub</p>
-        <span class="font-mono text-sm text-zmoki-flame-500">github.com</span>
+        <span
+          class="font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >github.com</span
+        >
       </a>
 
       <!-- Card 16 — 2x1 — Design system -->
@@ -251,7 +274,10 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Palette class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Design system</h2>
         <p class="text-sm md:text-base">colors, type, components</p>
-        <span class="font-mono text-sm text-zmoki-magenta-500">brand</span>
+        <span
+          class="font-mono text-sm text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4"
+          >brand</span
+        >
       </a>
 
       <!-- Card 15 — 1x1 — Legal -->
@@ -261,8 +287,16 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <Scale class="h-6 w-6 text-zmoki-muted" />
         <h2 class="text-xl font-semibold md:text-2xl">Legal</h2>
         <p class="flex flex-col gap-1">
-          <a href="/legal/privacy/" class="w-fit font-mono text-sm text-zmoki-muted">policy</a>
-          <a href="/legal/terms/" class="w-fit font-mono text-sm text-zmoki-muted">terms</a>
+          <a
+            href="/legal/privacy/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4"
+            >policy</a
+          >
+          <a
+            href="/legal/terms/"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4"
+            >terms</a
+          >
         </p>
       </article>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,8 +26,8 @@ const post1 = postByNumber(1);
 
 const dayThemes = await getEntry("resources", "day-themes-menu");
 
-const post1Image = post1 ? firstPostImage(post1.slug) : undefined;
-const dayThemesImage = imageUrl("/src/images/screenshot-notion-day-themes.png");
+const post1Image = post1 ? await firstPostImage(post1.slug) : undefined;
+const dayThemesImage = await imageUrl("/src/images/screenshot-notion-day-themes.png");
 ---
 
 <BaseLayout

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -108,9 +108,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
         <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
-        <p class="text-sm md:text-base">
-          Essays and deep dives where my interests connect. Read everything here.
-        </p>
+        <p class="text-base md:text-lg">Essays and deep dives where my interests connect.</p>
         <span class="font-mono text-sm text-zmoki-magenta-500">garden</span>
       </a>
 
@@ -148,8 +146,14 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
             )}
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-surface/95 via-zmoki-surface/60 to-zmoki-surface/10" />
             <div class="relative flex flex-col gap-2">
-              <h2 class="text-xl font-semibold md:text-2xl" set:html={dayThemes.data.title} />
-              <p class="text-sm opacity-90 md:text-base" set:html={dayThemes.data.description} />
+              <h2
+                class="text-xl font-semibold md:text-2xl"
+                set:html={dayThemes.data.title.replace(" Notion template", "")}
+              />
+              <p
+                class="text-sm opacity-90 md:text-base"
+                set:html={dayThemes.data.description.split(". ")[0] + "."}
+              />
               <span class="font-mono text-sm text-zmoki-jade-600">notion.com</span>
             </div>
           </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -289,12 +289,12 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         <p class="flex flex-col gap-1">
           <a
             href="/legal/privacy/"
-            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
             >policy</a
           >
           <a
             href="/legal/terms/"
-            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline"
+            class="w-fit font-mono text-sm text-zmoki-muted underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
             >terms</a
           >
         </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,20 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection, getEntry, type CollectionEntry } from "astro:content";
 import type { ImageMetadata } from "astro";
+import {
+  Activity,
+  BookOpen,
+  Briefcase,
+  CalendarDays,
+  Camera,
+  Code,
+  GitBranch,
+  Mail,
+  MapPin,
+  Palette,
+  Scale,
+  Sprout,
+} from "@lucide/astro";
 
 export const publishDate = new Date("2025-09-09");
 export const contentModifiedDate = new Date("2026-06-20");
@@ -73,6 +87,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         rel="noopener noreferrer"
         class="flex flex-col justify-end gap-4 rounded-xl bg-zmoki-surface p-8 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 lg:row-span-2"
       >
+        <Code class="h-6 w-6 text-zmoki-azure-500" />
         <h2 class="text-xl font-semibold md:text-2xl">The technical half</h2>
         <p class="text-base md:text-lg">
           As a Marketing Technologist I help marketers with engineering stuff.
@@ -84,6 +99,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <article
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
       >
+        <MapPin class="h-6 w-6 text-zmoki-ink" />
         <h2 class="text-xl font-semibold md:text-2xl">Based in</h2>
         <p class="text-sm md:text-base">
           <mark class="bg-zmoki-lemon box-decoration-clone px-1 text-zmoki-ink"
@@ -97,6 +113,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="/now/"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
+        <Activity class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Right now</h2>
         <p class="text-sm md:text-base">GoodINP, websites migration, paper collages</p>
         <span class="font-mono text-sm text-zmoki-magenta-500">now</span>
@@ -107,6 +124,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="/garden/"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
+        <Sprout class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">The digital garden</h2>
         <p class="text-base md:text-lg">Essays and deep dives where my interests connect.</p>
         <span class="font-mono text-sm text-zmoki-magenta-500">garden</span>
@@ -119,6 +137,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         rel="noopener noreferrer"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
+        <Camera class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Instagram</h2>
         <p class="text-sm md:text-base">the visual side</p>
         <span class="font-mono text-sm text-zmoki-magenta-500">@zmoki</span>
@@ -146,6 +165,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
             )}
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-surface/95 via-zmoki-surface/60 to-zmoki-surface/10" />
             <div class="relative flex flex-col gap-2">
+              <CalendarDays class="h-6 w-6 text-zmoki-jade-600" />
               <h2
                 class="text-xl font-semibold md:text-2xl"
                 set:html={dayThemes.data.title.replace(" Notion template", "")}
@@ -170,6 +190,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
           >
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
             <div class="relative flex flex-col gap-2">
+              <BookOpen class="h-6 w-6 text-slate-50" />
               <p class="font-mono text-xs uppercase tracking-normal opacity-80">
                 <time datetime={post1.data.contentModifiedDate.toISOString()}>
                   {post1.data.contentModifiedDate.toLocaleDateString("en-US", {
@@ -193,6 +214,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         rel="noopener noreferrer"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
+        <Briefcase class="h-6 w-6 text-zmoki-azure-500" />
         <h2 class="text-xl font-semibold md:text-2xl">LinkedIn</h2>
         <p class="text-sm md:text-base">the work side</p>
         <span class="font-mono text-sm text-zmoki-azure-500">@zaremakhalilova</span>
@@ -203,6 +225,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="mailto:hey@zmoki.xyz"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
+        <Mail class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Say hi</h2>
         <span class="font-mono text-2xl text-zmoki-flame-500 md:text-3xl">hey@zmoki.xyz</span>
       </a>
@@ -214,6 +237,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         rel="noopener noreferrer"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1"
       >
+        <GitBranch class="h-6 w-6 text-zmoki-flame-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Source code</h2>
         <p class="text-sm md:text-base">this site on GitHub</p>
         <span class="font-mono text-sm text-zmoki-flame-500">github.com</span>
@@ -224,6 +248,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
         href="/-/astro/brand/"
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md transition-transform hover:-translate-y-1 sm:col-span-2"
       >
+        <Palette class="h-6 w-6 text-zmoki-magenta-500" />
         <h2 class="text-xl font-semibold md:text-2xl">Design system</h2>
         <p class="text-sm md:text-base">colors, type, components</p>
         <span class="font-mono text-sm text-zmoki-magenta-500">brand</span>
@@ -233,6 +258,7 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
       <article
         class="flex flex-col justify-end gap-2 rounded-xl bg-zmoki-surface p-6 text-zmoki-ink shadow-md"
       >
+        <Scale class="h-6 w-6 text-zmoki-muted" />
         <h2 class="text-xl font-semibold md:text-2xl">Legal</h2>
         <p class="flex flex-col gap-1">
           <a href="/legal/privacy/" class="w-fit font-mono text-sm text-zmoki-muted">policy</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import { getCollection, getEntry, type CollectionEntry } from "astro:content";
 import type { ImageMetadata } from "astro";
 import {
   Activity,
-  BookOpen,
   Briefcase,
   CalendarDays,
   Camera,
@@ -204,7 +203,14 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
           >
             <div class="absolute inset-0 bg-gradient-to-t from-zmoki-ink/95 via-zmoki-ink/50 to-zmoki-ink/10" />
             <div class="relative flex flex-col gap-2">
-              <BookOpen class="h-6 w-6 text-slate-50" />
+              <p class="font-mono text-xs uppercase tracking-wider text-zmoki-magenta-400">
+                from the garden
+              </p>
+              <h2
+                class="text-xl font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline md:text-2xl"
+                set:html={post1.data.title}
+              />
+              <p class="text-sm opacity-90 md:text-base" set:html={post1.data.description} />
               <p class="font-mono text-xs uppercase tracking-normal opacity-80">
                 <time datetime={post1.data.contentModifiedDate.toISOString()}>
                   {post1.data.contentModifiedDate.toLocaleDateString("en-US", {
@@ -214,8 +220,6 @@ const dayThemesImage = imageAssets["/src/images/screenshot-notion-day-themes.png
                   })}
                 </time>
               </p>
-              <h2 class="text-xl font-semibold md:text-2xl" set:html={post1.data.title} />
-              <p class="text-sm opacity-90 md:text-base" set:html={post1.data.description} />
             </div>
           </a>
         )

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -4,6 +4,8 @@ import {
   publishDate as indexPagePublishDate,
   contentModifiedDate as indexPageContentModifiedDate,
 } from "@/pages/index.astro";
+import { contentModifiedDate as gardenPageContentModifiedDate } from "@/pages/garden.astro";
+import { contentModifiedDate as techPageContentModifiedDate } from "@/pages/tech.astro";
 import { frontmatter as nowPageFrontmatter } from "@/pages/now.mdx";
 
 const { contentModifiedDate: nowPageContentModifiedDate } = nowPageFrontmatter;
@@ -46,6 +48,8 @@ export const GET: APIRoute = async ({ site }) => {
     <loc>${site}</loc>
     <lastmod>${indexPageLatestDate}</lastmod>
   </url>
+  ${sitemapUrl("garden/", gardenPageContentModifiedDate.toISOString().substring(0, 10))}
+  ${sitemapUrl("tech/", techPageContentModifiedDate.toISOString().substring(0, 10))}
   ${sitemapUrl("now/", nowPageContentModifiedDate)}
   ${allFeedIems
     .map((post: CollectionEntry<"feed">) =>

--- a/src/pages/tech.astro
+++ b/src/pages/tech.astro
@@ -371,9 +371,11 @@ const externalLink =
   </main>
 
   <script is:inline>
-    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
-      window.posthog?.capture("contact_email_clicked", {
-        email: this.getAttribute("href").replace("mailto:", ""),
+    document.querySelectorAll('a[href^="mailto:"]').forEach(function (el) {
+      el.addEventListener("click", function () {
+        window.posthog?.capture("contact_email_clicked", {
+          email: this.getAttribute("href").replace("mailto:", ""),
+        });
       });
     });
   </script>

--- a/src/pages/tech.astro
+++ b/src/pages/tech.astro
@@ -1,0 +1,380 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+
+export const publishDate = new Date("2026-06-29");
+export const contentModifiedDate = new Date("2026-06-29");
+
+const marketerCards = [
+  {
+    title: "Your goals",
+    text: "Pipeline, signups, organic growth, the numbers you report on every month.",
+  },
+  {
+    title: "Your tools",
+    text: "The CRM, GA4, GTM, your email platform. I know them and how they break.",
+  },
+  {
+    title: "Your data",
+    text: "Attribution, funnels, search performance. I read it the way you do.",
+  },
+  {
+    title: "Your words",
+    text: "You explain it in marketing. I turn it into working code.",
+  },
+];
+
+const layers = [
+  {
+    label: "Layer one",
+    title: "Build the site",
+    text: "Bespoke marketing websites. Fast, custom, and built to be found.",
+  },
+  {
+    label: "Layer two",
+    title: "Wire the data",
+    text: "CRM and analytics connected, tracking that works, everything talking to everything.",
+  },
+  {
+    label: "Layer three",
+    title: "Set up the tools",
+    text: "The email and automation stack, stood up and running on top of it all.",
+  },
+];
+
+const aiCards = [
+  {
+    title: "Get found by AI search",
+    text: "I make sites that AI assistants quote and cite, so you show up where buyers now look.",
+  },
+  {
+    title: "Relevance engineering",
+    text: "I match your content to what people actually search and ask, using embeddings and vectors.",
+  },
+  {
+    title: "Build the AI itself",
+    text: "Embeddings analysis, question matching, retrieval. I build these systems myself.",
+  },
+  {
+    title: "Wire AI into the work",
+    text: "I plug AI tools into your marketing stack so the team ships faster than before.",
+  },
+];
+
+const projects = [
+  {
+    name: "Improvado",
+    tags: "Tech SEO → Relevance → AI rebuild",
+    text: "A large marketing analytics site. I started with technical SEO, then relevance engineering, matching their content to what people actually search and ask. Then I moved the site off Webflow onto a modern frontend stack, section by section, so their marketers could finally run the AI driven workflows the old setup blocked. Search traffic grew through the move and held steady through every Google core update since.",
+    stat: "Grew through the migration, held through core updates",
+  },
+  {
+    name: "vibepanic",
+    tags: "Built from scratch",
+    text: "A booking platform I am building from nothing. The whole thing, the booking flow, the CRM, and the analytics, wired together from scratch.",
+    stat: "From zero to a working platform",
+  },
+  {
+    name: "RealAdvisor",
+    tags: "Technical SEO",
+    text: "A Swiss property platform with thousands of listing pages. I rebuilt the technical SEO from the frontend up, added structured data, automated the meta generation, and made the pages load three times faster.",
+    stat: "247K → 546K clicks over two years",
+  },
+  {
+    name: "3commas",
+    tags: "Migrated",
+    text: "A crypto trading platform. I migrated the marketing site to a new stack without losing the organic traffic it ran on. One of a line of migrations I have done since 2018, Uploadcare among them.",
+    stat: "Since 2018 migrations, no traffic lost",
+  },
+];
+
+const articles = [
+  {
+    title: "The strategic power of questions, from theory to SEO and AI search",
+    category: "AI search & relevance",
+    text: "How the shape of a question decides what content wins in search and in AI answers. With real Search Console and BigQuery data across two sites.",
+    url: "/feed/16-power-of-questions/",
+  },
+  {
+    title: "My tech SEO recommendations for new websites",
+    category: "Technical SEO",
+    text: "A practical checklist for launching a new site the right way. Domains, security headers, sitemaps, canonicals, and the content that earns trust.",
+    url: "/feed/13-new-website-seo-checklist/",
+  },
+];
+
+const stack = [
+  { group: "Build & host", tools: ["Astro", "Webflow", "Cloudflare", "AWS", "Google Cloud"] },
+  {
+    group: "Search & analytics",
+    tools: [
+      "Search Console",
+      "Bing Webmaster Tools",
+      "GA4",
+      "PostHog",
+      "Mixpanel",
+      "Looker Studio",
+    ],
+  },
+  { group: "Tracking & data", tools: ["Google Tag Manager", "BigQuery"] },
+  { group: "Email & automation", tools: ["Brevo", "lemlist"] },
+  { group: "AI", tools: ["Claude Code", "Embeddings & vector search", "OpenRouter"] },
+];
+
+const eyebrow = "font-mono text-sm uppercase tracking-wider text-zmoki-azure-500";
+const headline = "text-3xl font-semibold leading-tight md:text-4xl";
+const section = "space-y-8 border-t border-zmoki-azure-200 pt-12";
+const externalLink =
+  "font-mono text-sm text-zmoki-flame-500 underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline";
+---
+
+<BaseLayout
+  title="The Technical Half — Zarema Khalilova"
+  description="Marketing Technologist. I build the websites, wire up the data behind them, set up the tools on top, and bring the AI that ties it all together."
+>
+  <main class="p-2 lg:p-4">
+    <div
+      class="mx-auto max-w-3xl space-y-16 rounded-xl bg-zmoki-surface p-6 leading-relaxed text-zmoki-ink shadow-md md:p-16"
+    >
+      <!-- Nav -->
+      <nav class="flex flex-wrap items-center justify-between gap-4 font-mono text-sm">
+        <span class="font-semibold"
+          ><span class="text-zmoki-azure-500">½</span> The Technical Half</span
+        >
+        <span class="flex flex-wrap gap-4">
+          <a href="/" class="text-zmoki-magenta-500">home</a>
+          <a href="/garden/" class="text-zmoki-magenta-500">garden</a>
+          <a href="#contact" class="text-zmoki-flame-500">get in touch</a>
+        </span>
+      </nav>
+
+      <!-- Hero -->
+      <header class="space-y-6">
+        <p class={eyebrow}>½ Marketing Technologist</p>
+        <h1 class="text-4xl font-semibold leading-tight sm:text-5xl md:text-6xl">
+          I'm the technical <em class="italic text-zmoki-azure-500">half</em> of your marketing team.
+        </h1>
+        <p class="text-lg opacity-80 md:text-xl">
+          I build the websites, wire up the data behind them, set up the tools on top, and bring the
+          AI that ties it all together. The part your marketers can't build, made by someone on
+          their side of the table.
+        </p>
+        <p class="text-2xl font-semibold text-zmoki-azure-500 md:text-3xl">
+          You bring the plan. I build the machine.
+        </p>
+        <div class="flex flex-wrap gap-4 pt-2">
+          <a
+            href="mailto:hey@zmoki.xyz"
+            class="inline-flex rounded-lg bg-zmoki-azure-500 px-5 py-3 font-medium text-slate-50 transition hover:-translate-y-0.5 hover:shadow-lg hover:shadow-zmoki-azure-500/40"
+            >Email me</a
+          >
+          <a
+            href="https://www.linkedin.com/company/thetechnicalhalf/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex rounded-lg border-2 border-zmoki-azure-500 px-5 py-3 font-medium text-zmoki-azure-500 transition hover:-translate-y-0.5"
+            >The Technical Half on LinkedIn</a
+          >
+        </div>
+      </header>
+
+      <!-- Engineer buddy for marketers -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ Engineer buddy for marketers</p>
+          <h2 class={headline}>I get how marketers work.</h2>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
+          {
+            marketerCards.map((item) => (
+              <div class="space-y-1">
+                <h3 class="text-xl font-semibold text-zmoki-azure-500">{item.title}</h3>
+                <p class="opacity-80">{item.text}</p>
+              </div>
+            ))
+          }
+        </div>
+      </section>
+
+      <!-- What I do -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ What I do</p>
+          <h2 class={headline}>I build the whole technical half.</h2>
+          <p class="text-lg opacity-80">
+            Three layers, one person. The site people see, the data underneath it, and the tools
+            sitting on top.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-3">
+          {
+            layers.map((layer) => (
+              <div class="space-y-1">
+                <p class="font-mono text-xs uppercase tracking-wider opacity-60">{layer.label}</p>
+                <h3 class="text-xl font-semibold text-zmoki-azure-500">{layer.title}</h3>
+                <p class="opacity-80">{layer.text}</p>
+              </div>
+            ))
+          }
+        </div>
+        <p class="text-lg opacity-80">
+          Some of it I build from scratch. Some of it I fix or rebuild. Some of it is just the right
+          tool, plugged in well. <span class="font-semibold opacity-100"
+            >I know which you need, and I do all of it.</span
+          >
+        </p>
+      </section>
+
+      <!-- Where I go deep -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ Where I go deep</p>
+          <h2 class={headline}>The AI part is where I'm strongest.</h2>
+          <p class="text-lg opacity-80">
+            Real AI work, from getting found by AI search to building the systems underneath it.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
+          {
+            aiCards.map((item) => (
+              <div class="space-y-1">
+                <h3 class="text-xl font-semibold text-zmoki-azure-500">{item.title}</h3>
+                <p class="opacity-80">{item.text}</p>
+              </div>
+            ))
+          }
+        </div>
+      </section>
+
+      <!-- Some of what I built -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ Some of what I built</p>
+          <h2 class={headline}>Proof you can check.</h2>
+          <p class="text-lg opacity-80">
+            A few of the jobs I have taken on, each a different kind of technical work.
+          </p>
+        </div>
+        <div class="divide-y divide-zmoki-azure-200">
+          {
+            projects.map((project) => (
+              <div class="space-y-2 py-6 first:pt-0 last:pb-0">
+                <p class="font-mono text-xs uppercase tracking-wider text-zmoki-azure-500">
+                  {project.tags}
+                </p>
+                <h3 class="text-2xl font-semibold">{project.name}</h3>
+                <p class="opacity-80">{project.text}</p>
+                <p class="font-semibold text-zmoki-azure-500">{project.stat}</p>
+              </div>
+            ))
+          }
+        </div>
+      </section>
+
+      <!-- Thinking in public -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ Thinking in public</p>
+          <h2 class={headline}>I write about the work.</h2>
+          <p class="text-lg opacity-80">
+            Long pieces on how this actually works, with real data. The kind of thing you can read
+            before you decide to talk to me.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
+          {
+            articles.map((article) => (
+              <a href={article.url} class="group block space-y-2">
+                <p class="font-mono text-xs uppercase tracking-wider text-zmoki-magenta-500">
+                  {article.category}
+                </p>
+                <h3 class="text-xl font-semibold underline decoration-dotted decoration-2 underline-offset-4 group-hover:no-underline">
+                  {article.title}
+                </h3>
+                <p class="opacity-80">{article.text}</p>
+                <span class="font-mono text-sm text-zmoki-magenta-500">read in the garden →</span>
+              </a>
+            ))
+          }
+        </div>
+        <p class="opacity-80">
+          I write everything in my <a
+            href="/garden/"
+            class="text-zmoki-magenta-500 underline decoration-dotted decoration-2 underline-offset-4 hover:no-underline"
+            >digital garden</a
+          > first. This is a slice of it.
+        </p>
+      </section>
+
+      <!-- What I work with -->
+      <section class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ What I work with</p>
+          <h2 class={headline}>The stack, grouped by job.</h2>
+          <p class="text-lg opacity-80">
+            The tools I reach for across the layers I build. The build, the search and data, the
+            email, and the AI on top.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
+          {
+            stack.map((group) => (
+              <div class="space-y-1">
+                <h3 class="text-lg font-semibold text-zmoki-azure-500">{group.group}</h3>
+                <p class="opacity-80">{group.tools.join(" · ")}</p>
+              </div>
+            ))
+          }
+        </div>
+        <p class="opacity-80">
+          And this is a slice of it. <span class="font-semibold opacity-100"
+            >I pick up whatever a project needs</span
+          >, and the list keeps growing.
+        </p>
+      </section>
+
+      <!-- Contact -->
+      <section id="contact" class={section}>
+        <div class="space-y-3">
+          <p class={eyebrow}>½ Get in touch</p>
+          <h2 class={headline}>Need the other half of your team?</h2>
+          <p class="text-lg opacity-80">
+            Tell me what your marketing is trying to do. I'll tell you what it takes to build it.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-x-6 gap-y-2">
+          <a href="mailto:hey@zmoki.xyz" class={externalLink}>hey@zmoki.xyz</a>
+          <a
+            href="https://www.linkedin.com/company/thetechnicalhalf/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class={externalLink}>The Technical Half on LinkedIn</a
+          >
+          <a
+            href="https://www.linkedin.com/in/zaremakhalilova/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class={externalLink}>Zarema on LinkedIn</a
+          >
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer
+        class="flex flex-col gap-1 border-t border-zmoki-azure-200 pt-8 font-mono text-sm opacity-60"
+      >
+        <span
+          ><span class="text-zmoki-azure-500">½</span> The Technical Half is one facet of zmoki.xyz</span
+        >
+        <span>Zarema Khalilova · Tbilisi · Remote</span>
+      </footer>
+    </div>
+  </main>
+
+  <script is:inline>
+    document.querySelector('a[href^="mailto:"]')?.addEventListener("click", function () {
+      window.posthog?.capture("contact_email_clicked", {
+        email: this.getAttribute("href").replace("mailto:", ""),
+      });
+    });
+  </script>
+</BaseLayout>

--- a/src/utils/post-image.ts
+++ b/src/utils/post-image.ts
@@ -1,4 +1,5 @@
 import type { ImageMetadata } from "astro";
+import { getImage } from "astro:assets";
 
 // Raw source of every feed post, and every image in src/images. Both globs are
 // resolved at build time by Vite, so they work from any importing module.
@@ -12,17 +13,24 @@ const imageAssets = import.meta.glob("/src/images/*.{jpg,jpeg,png,webp,avif}", {
   eager: true,
 }) as Record<string, { default: ImageMetadata }>;
 
-/** Optimized URL for an image in src/images, addressed by its repo-root path. */
-export function imageUrl(path: string): string | undefined {
-  return imageAssets[path]?.default.src;
+// Cards never display these wider than ~half the grid, so cap and re-encode to
+// WebP instead of serving the full-resolution original as a background.
+const CARD_IMAGE_WIDTH = 800;
+
+/** Optimized (resized WebP) URL for an image in src/images, by repo-root path. */
+export async function imageUrl(path: string): Promise<string | undefined> {
+  const asset = imageAssets[path]?.default;
+  if (!asset) return undefined;
+  const optimized = await getImage({ src: asset, width: CARD_IMAGE_WIDTH, format: "webp" });
+  return optimized.src;
 }
 
 /**
- * Resolve the first <PostImage> used in a post and return its optimized URL,
+ * Resolve the first <PostImage> used in a post and return an optimized URL,
  * so a card can use the post's own photo as a background. Returns undefined
  * when the post has no <PostImage>.
  */
-export function firstPostImage(slug: string): string | undefined {
+export async function firstPostImage(slug: string): Promise<string | undefined> {
   const sourceKey = Object.keys(postSources).find(
     (key) => key.endsWith(`/${slug}.mdx`) || key.endsWith(`/${slug}.md`),
   );

--- a/src/utils/post-image.ts
+++ b/src/utils/post-image.ts
@@ -1,0 +1,37 @@
+import type { ImageMetadata } from "astro";
+
+// Raw source of every feed post, and every image in src/images. Both globs are
+// resolved at build time by Vite, so they work from any importing module.
+const postSources = import.meta.glob("/src/content/feed/*.{md,mdx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+const imageAssets = import.meta.glob("/src/images/*.{jpg,jpeg,png,webp,avif}", {
+  eager: true,
+}) as Record<string, { default: ImageMetadata }>;
+
+/** Optimized URL for an image in src/images, addressed by its repo-root path. */
+export function imageUrl(path: string): string | undefined {
+  return imageAssets[path]?.default.src;
+}
+
+/**
+ * Resolve the first <PostImage> used in a post and return its optimized URL,
+ * so a card can use the post's own photo as a background. Returns undefined
+ * when the post has no <PostImage>.
+ */
+export function firstPostImage(slug: string): string | undefined {
+  const sourceKey = Object.keys(postSources).find(
+    (key) => key.endsWith(`/${slug}.mdx`) || key.endsWith(`/${slug}.md`),
+  );
+  if (!sourceKey) return undefined;
+  const source = postSources[sourceKey];
+  const usage = source.match(/<PostImage[^>]*\bsrc=\{(\w+)\}/);
+  if (!usage) return undefined;
+  const importMatch = source.match(new RegExp(`import\\s+${usage[1]}\\s+from\\s+["']([^"']+)["']`));
+  if (!importMatch) return undefined;
+  const assetKey = importMatch[1].replace("@/images/", "/src/images/");
+  return imageUrl(assetKey);
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -68,21 +68,12 @@ export default {
   },
   plugins: [
     require("@tailwindcss/typography"),
-    // Global link interaction, driven by the brand tokens. Lives in the base
-    // layer so every page inherits identical behavior — no per-layout class
-    // strings to copy or forget (this used to be a `[&_a]` body class on
-    // BaseLayout only, which is why brand pages had dead links).
+    // Strip the default underline from links site-wide; per-context link
+    // styling (prose colors, bento cards) is handled where it's used.
     plugin(({ addBase }) => {
       addBase({
         a: {
           "text-decoration": "none",
-          transition: "all 200ms",
-        },
-        "a:hover": {
-          backgroundColor: brandColors["zmoki-azure"][500],
-          color: "#fff",
-          outlineStyle: "solid",
-          outlineColor: brandColors["zmoki-azure"][500],
         },
       });
     }),


### PR DESCRIPTION
Rebuilds the site around a true bento aesthetic and adds two new pages.

## Highlights
- **Homepage** rebuilt as a 4-column bento grid: intro, social/work links, milestone stats → now image-backed featured post, Day Themes resource, contact, legal, source, design system.
- **New `/garden/` page** — bento header + posts (newest featured with its own photo) at 3/4 width and a resources rail at 1/4.
- **New `/tech/` page** — "The Technical Half" landing page mirroring tech.zarema.me's typographic structure (½ motif, ruled sections, project list, stack groups), recolored with zmoki tokens.
- **Post, now, and legal layouts** centered (`max-w-4xl`) with a shared top-nav bento (home/garden/say hi) and footer bento (source/design/legal).

## Design system
- Palette shifted to the azure family: added `zmoki-azure-50`, `surface → azure-50`, `bg → azure-200`, plus `zmoki-jade-600`.
- Cards unified on surface/ink with color-coded mono link identifiers (external=flame, internal=magenta, resource=jade) and dotted underlines.
- Card hover: lift + accent-colored shadow, underline clears on hover.
- Removed the global azure link-hover flip.
- Lucide icons (`@lucide/astro`) on cards.

## Plumbing
- Extracted `src/utils/post-image.ts` (resolves a post's first image), shared by home and garden.
- Stripped `BaseLayout` to a bare slot; per-page layouts own their chrome.
- Analytics: fixed `resource_link_clicked` on the homepage and switched all mailto handlers to `querySelectorAll` so every contact link fires `contact_email_clicked`.
- Added `/garden/` and `/tech/` to the sitemap.

## Checks
`npm run check` and `npm run lint` pass; all pages render locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)